### PR TITLE
fix(filter): introduce ValuePattern AST to disambiguate LIKE wildcards

### DIFF
--- a/_ai/F0001-filter-escaping/F0001.md
+++ b/_ai/F0001-filter-escaping/F0001.md
@@ -22,16 +22,57 @@ Implement the support of escaping in the doka parser. Those charaters should be 
 
 # Ouputs
   - when a filter is incorrect, we should return a syntax error like today
-  - when the filter is correct, its string literal should be converted into a valid string in the intermediate state :  
-    - "super #"extra#" player" gives : super "extra" player
-    - "less than 10 #%"  gives : less than 10 %
+  - when the filter is correct, its string literal is converted into a value in the intermediate AST. The AST representation **depends on the operator**:
 
-  
+## Non-LIKE operators (`==`, `!=`, `<`, `<=`, `>`, `>=`)
+
+The string literal becomes a `FilterValue::ValueString(String)` containing **pure literal text** — every escape sequence is resolved and no character has any remaining metacharacter meaning. Examples (canonical form on the right):
+
+  - `"super #"extra#" player"` → `super "extra" player`
+  - `"less than 10 #%"` → `less than 10 %`
+  - `"see paragraph ##6"` → `see paragraph #6`
+
+Inside a `ValueString`, a `%` always means "the literal percent character".
+
+## `LIKE` operator
+
+The string literal becomes a `FilterValue::ValuePattern(Vec<PatternPart>)` where:
+
+```rust
+enum PatternPart {
+    Literal(String),  // pure literal text — no metacharacter
+    AnySequence,      // the SQL `%` wildcard (matches any sequence of characters)
+}
+```
+
+A bare `%` in the source is an `AnySequence`. An escaped `#%` is a literal `%` and ends up inside a `Literal(...)` segment. Adjacent literal characters are merged into a single `Literal` segment. Consecutive `AnySequence` parts are collapsed into one.
+
+### Canonical form (for tests and debugging)
+
+To make the structure visible in tests, the canonical printer renders a `ValuePattern` as follows:
+
+  - each `Literal(s)` is rendered as its raw text `s` (no surrounding marker)
+  - each `AnySequence` is rendered as `\%\` — the `%` is surrounded by backslashes so it stands out from any literal `%` produced by an escaped `#%`
+  - segments are concatenated with no separator
+
+Examples:
+
+| Source                 | AST                                                | Canonical form         |
+|------------------------|----------------------------------------------------|------------------------|
+| `LIKE "den%"`          | `[Literal("den"), AnySequence]`                    | `den\%\`               |
+| `LIKE "50#%"`          | `[Literal("50%")]`                                 | `50%`                  |
+| `LIKE "%foo%"`         | `[AnySequence, Literal("foo"), AnySequence]`       | `\%\foo\%\`            |
+| `LIKE "a%b#%c"`        | `[Literal("a"), AnySequence, Literal("b%c")]`      | `a\%\b%c`              |
+| `LIKE "%"`             | `[AnySequence]`                                    | `\%\`                  |
+| `LIKE ""`              | `[Literal("")]`                                    | ``                     |
+
 # Preconditions
 - none
 
 # Postconditions
-- Not a simple forbidden char appears alone in the original string literal.
+- No isolated forbidden char (`"`, `%`, `#`) appears in the original string literal.
+- A `FilterValue::ValueString` contains **pure literal text** — no character carries any metacharacter meaning. In particular, a `%` inside a `ValueString` is a literal percent, never a wildcard.
+- A `FilterValue::ValuePattern` is the **only** AST representation that can carry a wildcard. The wildcard is always an explicit `PatternPart::AnySequence`, never an in-string `%`.
 
 # Business rules
 - In a string literal, #, % and " **must** be prefixed by a # to be considered as valid.

--- a/_ai/F0001-filter-escaping/unit_tests_filter_escaping.md
+++ b/_ai/F0001-filter-escaping/unit_tests_filter_escaping.md
@@ -19,8 +19,7 @@ Syntax (DFS), as specified in [F0001.md](F0001.md) and §6 of
   in the intermediate value produced by the parser;
 - the canonical form printed by the server after unescaping;
 - syntax errors (`InvalidEscapeSequence`) when the escape rules are violated;
-- regression on plain strings and on the `%` wildcard in `LIKE` (see
-  "Open questions").
+- regression on plain strings and on the `%` wildcard in `LIKE`.
 
 System under test: the filter parser in
 [`document-server/src/filter/mod.rs`](../../document-server/src/filter/mod.rs)
@@ -169,8 +168,9 @@ When:
 - the expression is parsed
 
 Then:
-- parsing succeeds (the `%` remains a `LIKE` wildcard)
-- canonical form: `([name<LIKE>den%])`
+- parsing succeeds (the bare `%` is interpreted as the wildcard)
+- AST value: `ValuePattern([Literal("den"), AnySequence])`
+- canonical form: `([name<LIKE>den\%\])`
 
 ## TC-F0001-013 — Literal `#%` inside a `LIKE`
 Given:
@@ -181,7 +181,21 @@ When:
 
 Then:
 - parsing succeeds
-- the literal value is `50%` and stands for a literal `%`, not a wildcard
+- the escaped `#%` is consumed as a literal percent (no wildcard)
+- AST value: `ValuePattern([Literal("50%")])`
+- canonical form: `([code<LIKE>50%])`
+
+## TC-F0001-013b — Wildcard surrounded by literals in a `LIKE`
+Given:
+- filter expression: `name LIKE "%foo#%bar%"`
+
+When:
+- the expression is parsed
+
+Then:
+- parsing succeeds
+- AST value: `ValuePattern([AnySequence, Literal("foo%bar"), AnySequence])`
+- canonical form: `([name<LIKE>\%\foo%bar\%\])`
 
 ## TC-F0001-014 — Preserved historical error: `\` is not an escape
 Given:
@@ -193,24 +207,5 @@ When:
 Then:
 - parsing fails (the `\` has no special status — the first `"` after `\`
   closes the string and the rest is invalid)
-- guards against any regression toward the old `\` escape proposal
-
-- **Error message wording**: F0001 specifies the message
-  `Invalid escape sequence in string literal at position {char_position}`,
-  matching the existing `human_error_message` style (English sentence ending
-  with `at position {char_position}`, no `{}` placeholder for the offending
-  character). The test cases above only assert the substring
-  `Invalid escape sequence in string literal` to keep the position-suffix
-  formatting flexible.
-
-# Coverage vs F0001
-
-| F0001 rule                                                | Test cases                       |
-|-----------------------------------------------------------|----------------------------------|
-| `#"` → `"`                                                | TC-F0001-001, 004, 005           |
-| `#%` → `%`                                                | TC-F0001-002, 004, 005, 013      |
-| `##` → `#`                                                | TC-F0001-003, 004                |
-| `#` not followed by `#`/`%`/`"` is an error               | TC-F0001-007, 008, 009           |
-| Trailing `#` → unterminated string                        | TC-F0001-010                     |
-| Bare forbidden char (`%` outside `LIKE`)                  | TC-F0001-011                     |
-| Regression (plain string, `LIKE` wildcard, `\`)           | TC-F0001-006, 012, 014           |
+- guards against any regression toward the `\` escape idea
+- output the standard error message

--- a/_ai/specs/filter-syntax.md
+++ b/_ai/specs/filter-syntax.md
@@ -24,8 +24,8 @@ Notes:
 - There is no `NULL` / missing value — every condition must supply a value.
 - Dates are written as strings in ISO 8601 form (`"YYYY-MM-DD"`) and compared
   lexicographically. There is no dedicated date type.
-- Today, a literal `"`, `%` or `#` cannot appear inside a quoted value. A
-  hash escape (`#"`, `#%`, `##`) is planned — see §6.
+- A literal `"`, `%` or `#` inside a quoted value must be written with a
+  hash escape (`#"`, `#%`, `##`) — see §6.
 
 ### 2. Operators by type
 
@@ -82,16 +82,11 @@ and `age <40` are all accepted.
 | Char    | Role                                                                    |
 |---------|-------------------------------------------------------------------------|
 | `"`     | Delimits a string literal. Required for every string value, including dates. No escape syntax. |
-| `%`     | Wildcard — **only meaningful inside a string used with `LIKE`**. Matches zero or more characters. Example: `name LIKE "den%"`. Outside a `LIKE` value it is just a literal `%`. |
+| `%`     | Wildcard — **only legal as a bare character inside a string used with `LIKE`**, where it matches zero or more characters. Example: `name LIKE "den%"`. A literal `%` (anywhere, including inside a `LIKE` value) must be written `#%`. A bare `%` outside a `LIKE` value is a syntax error (`InvalidEscapeSequence`). |
 | `(` `)` | Logical grouping (see §3).                                              |
 | `#`     | Escape prefix inside a string literal — see §6. Has no meaning outside a string literal. |
 
-### 6. Escaping in text constants (planned — not yet implemented)
-
-> **Status:** specified but not yet implemented in the parser. The current
-> lexer does **not** recognise `#` as an escape character; until this is
-> released, the rules below are forward-looking and the characters listed
-> simply cannot appear in a string value.
+### 6. Escaping in text constants
 
 Inside a string constant `"abcd"`, three characters are forbidden as
 literals because they collide with the filter syntax or with the SQL
@@ -103,7 +98,7 @@ wildcard. They must be escaped with a leading `#`:
 | `%`       | `LIKE` wildcard               | `#%`            |
 | `#`       | The escape character itself   | `##`            |
 
-Examples (future syntax):
+Examples:
 
 - `category == "super #"extra#" player"` — embedded double quotes; the
   string value becomes `super "extra" player`.
@@ -112,14 +107,10 @@ Examples (future syntax):
 - `comment == "see paragraph ##6"` — literal `#`; the value becomes
   `see paragraph #6`.
 
-A `#` inside a string literal **must** be the start of one of the three
-escape sequences above. A `#` that is **not** followed by `#`, `%` or `"`
-is a syntax error (`InvalidEscapeSequence`). For example,
-`"see paragraph #6"` is rejected because the `#` is followed by `6`; the
-correct form is `"see paragraph ##6"`. A trailing `#` at the very end of a
-literal (e.g. `"hello #"`) is also rejected, but as `UnclosedQuote` rather
-than `InvalidEscapeSequence` — the `#"` is consumed as an escaped quote, so
-the string is left unterminated.
+A `#` inside a string literal **must** be the start of one of the three escape sequences above. 
+A `#` that is **not** followed by `#`, `%` or `"` is a syntax error (`InvalidEscapeSequence`).
+    For example, `"see paragraph #6"` is rejected because the `#` is followed by `6`; the correct form is `"see paragraph ##6"`. 
+A trailing `#` at the very end of a literal (e.g. `"hello #"`) is also rejected, but as `UnclosedQuote` rather than `InvalidEscapeSequence` — the `#"` is consumed as an escaped quote, so sthe string is left unterminated.
 
 ### 7. Parenthesis combinations — worked examples
 
@@ -133,10 +124,11 @@ shapes shown are exact.
 | `age < 40 AND (birthdate >= "2001-01-01")`                            | `([age<LT>40]AND[birthdate<GTE>2001-01-01])`                                                    |
 | `(age < 40) OR (question == TRUE)`                                    | `([age<LT>40]OR[question<EQ>TRUE])`                                                             |
 | `age < 40 OR age > 21 AND detail == "bonjour"`                        | `(([age<LT>40]OR[age<GT>21])AND[detail<EQ>bonjour])` *(implicit precedence)*                    |
-| `(attribut3 LIKE "den%")`                                             | `([attribut3<LIKE>den%])`                                                                       |
+| `(attribut3 LIKE "den%")`                                             | `([attribut3<LIKE>den\%\])` — `\%\` is the wildcard; a bare `%` here would mean a literal `%`   |
+| `(code LIKE "50#%")`                                                  | `([code<LIKE>50%])` — `#%` is the literal percent (no wildcard); contrast with the row above    |
 | `((country == "FR" AND (science >= 40)) OR (lost_in_hell == "TRUE"))` | `(([country<EQ>FR]AND[science<GTE>40])OR[lost_in_hell<EQ>TRUE])`                                |
-| `category == "super #"extra#" player"` *(planned, see §6)*            | `([category<EQ>super "extra" player])` — `#"` is unescaped to `"` before the value is printed   |
-| `percent == "less than 10 #%"` *(planned, see §6)*                    | `([percent<EQ>less than 10 %])` — `#%` is unescaped to `%`                                      |
+| `category == "super #"extra#" player"`                                | `([category<EQ>super "extra" player])` — `#"` is unescaped to `"` before the value is printed   |
+| `percent == "less than 10 #%"`                                        | `([percent<EQ>less than 10 %])` — `#%` is unescaped to `%`                                      |
 
 ### 8. Canonical / debug form
 
@@ -151,6 +143,10 @@ know the conventions:
   same level, the server inserts parentheses to make precedence explicit.
 - String values appear **without** their surrounding quotes.
 - Booleans appear as `TRUE` / `FALSE`.
+- For a `LIKE` value, the canonical form distinguishes the wildcard from a
+  literal `%`: the wildcard is printed as `\%\`, while any `%` appearing bare
+  is a literal percent (it can only be there because the source used `#%`).
+  Example: `LIKE "den%"` → `den\%\`, while `LIKE "50#%"` → `50%`.
 
 This is the bridge between what you typed and what the server reports.
 

--- a/document-server/src/filter/filter_ast.rs
+++ b/document-server/src/filter/filter_ast.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use crate::filter::filter_lexer::FilterErrorCode::{
     AttributeExpected, ClosingExpected, LogicalOperatorExpected, OpeningExpected, OperatorExpected, ValueExpected,
 };
-use crate::filter::filter_lexer::{FilterError, LogicalOperator, Token};
+use crate::filter::filter_lexer::{FilterError, LogicalOperator, PatternPart, Token};
 use commons_error::*;
 use log::*;
 use rs_uuid::uuid8;
@@ -33,6 +33,7 @@ pub(crate) enum ComparisonOperator {
 pub(crate) enum FilterValue {
     ValueInt(i32),
     ValueString(String),
+    ValuePattern(Vec<PatternPart>),
     ValueBool(bool),
 }
 
@@ -44,6 +45,15 @@ impl fmt::Display for FilterValue {
             }
             FilterValue::ValueString(s) => {
                 write!(f, "{}", s.as_str())
+            }
+            FilterValue::ValuePattern(parts) => {
+                for part in parts {
+                    match part {
+                        PatternPart::Literal(s) => write!(f, "{}", s)?,
+                        PatternPart::AnySequence => write!(f, r"\%\")?,
+                    }
+                }
+                Ok(())
             }
             FilterValue::ValueBool(b) => {
                 write!(f, "{}", if *b { "TRUE" } else { "FALSE" })
@@ -249,6 +259,7 @@ fn parse_condition(tokens: &[Token], index: &RefCell<usize>) -> Result<Box<Filte
                         // FIXEME : should keep the position
                         Token::ValueInt(op) => FilterValue::ValueInt(op.clone().token),
                         Token::ValueString(op) => FilterValue::ValueString(op.clone().token),
+                        Token::ValuePattern(op) => FilterValue::ValuePattern(op.clone().token),
                         Token::ValueBool(op) => FilterValue::ValueBool(op.clone().token),
                         _ => {
                             warn!("Must be a token value"); // TODO NORM

--- a/document-server/src/filter/filter_lexer.rs
+++ b/document-server/src/filter/filter_lexer.rs
@@ -27,12 +27,26 @@ impl<T> PositionalToken<T> {
     }
 }
 
+/// One segment of a `LIKE` value, as captured by the lexer.
+///
+/// A bare `%` in the source (inside a `LIKE` string literal) becomes an
+/// `AnySequence`. An escaped `#%` is consumed as a literal `%` and ends up
+/// inside the surrounding `Literal(...)` segment. Adjacent literal characters
+/// are merged into a single `Literal`; consecutive `AnySequence` parts are
+/// collapsed into one. See F0001.md for the full spec.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum PatternPart {
+    Literal(String),
+    AnySequence,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Token {
     Attribute(PositionalToken<String>),
     Operator(PositionalToken<ComparisonOperator>),
     ValueInt(PositionalToken<i32>),
     ValueString(PositionalToken<String>),
+    ValuePattern(PositionalToken<Vec<PatternPart>>),
     ValueBool(PositionalToken<bool>),
     BinaryLogicalOperator(PositionalToken<LogicalOperator>),
     ConditionOpen(PositionalToken<()>),  // [
@@ -69,6 +83,7 @@ impl Token {
             Token::Operator(p) => p.position,
             Token::ValueInt(p) => p.position,
             Token::ValueString(p) => p.position,
+            Token::ValuePattern(p) => p.position,
             Token::ValueBool(p) => p.position,
             Token::BinaryLogicalOperator(p) => p.position,
             Token::ConditionOpen(p) => p.position,
@@ -84,6 +99,7 @@ impl Token {
             Token::Operator(p) => p.position = (p.position as i32 + nb) as usize,
             Token::ValueInt(p) => p.position = (p.position as i32 + nb) as usize,
             Token::ValueString(p) => p.position = (p.position as i32 + nb) as usize,
+            Token::ValuePattern(p) => p.position = (p.position as i32 + nb) as usize,
             Token::ValueBool(p) => p.position = (p.position as i32 + nb) as usize,
             Token::BinaryLogicalOperator(p) => p.position = (p.position as i32 + nb) as usize,
             Token::ConditionOpen(p) => p.position = (p.position as i32 + nb) as usize,
@@ -125,6 +141,16 @@ impl fmt::Display for Token {
             ),
             Token::ValueInt(pt) => write!(f, "{}", pt.token),
             Token::ValueString(pt) => write!(f, "\"{}\"", pt.token),
+            Token::ValuePattern(pt) => {
+                write!(f, "\"")?;
+                for part in &pt.token {
+                    match part {
+                        PatternPart::Literal(s) => write!(f, "{}", s)?,
+                        PatternPart::AnySequence => write!(f, r"\%\")?,
+                    }
+                }
+                write!(f, "\"")
+            }
             Token::ValueBool(pt) => write!(f, "{}", pt.token),
             Token::BinaryLogicalOperator(pt) => write!(
                 f,
@@ -450,6 +476,10 @@ fn condition_lexer_index(
     let mut fop: String = String::new();
     let mut text_mode = false;
     let mut was_string = false;
+    // text-mode accumulators: build a structured pattern in case the value is for LIKE.
+    // For non-LIKE operators, `append_value` will flatten this into a plain ValueString.
+    let mut pattern_parts: Vec<PatternPart> = Vec::new();
+    let mut lit_buf: String = String::new();
 
     parser_log!(
         "Condition reading start at {}", *index.borrow();
@@ -471,7 +501,14 @@ fn condition_lexer_index(
                         error_code: FilterErrorCode::InvalidLogicalDepth,
                     });
                 } else {
-                    append_value(&mut value, was_string, &mut tokens, *index.borrow(), offset)?;
+                    append_value(
+                        &mut value,
+                        &mut pattern_parts,
+                        was_string,
+                        &mut tokens,
+                        *index.borrow(),
+                        offset,
+                    )?;
                     break;
                 }
             }
@@ -491,11 +528,19 @@ fn condition_lexer_index(
                     }
                     ConditionExpectedLexeme::Value => {
                         if text_mode {
-                            value.push(grapheme_at_index);
+                            // A space inside a string literal — part of the current literal segment.
+                            lit_buf.push(grapheme_at_index);
                         } else {
                             // for non text value, it marks the end of the condition
                             if !value.is_empty() {
-                                append_value(&mut value, false, &mut tokens, *index.borrow(), offset)?;
+                                append_value(
+                                    &mut value,
+                                    &mut pattern_parts,
+                                    false,
+                                    &mut tokens,
+                                    *index.borrow(),
+                                    offset,
+                                )?;
                                 break; // Here is the end of the condition processing
                             }
                         }
@@ -509,13 +554,24 @@ fn condition_lexer_index(
                 );
 
                 if text_mode {
-                    // Cannot exit condition processing if we are in text mode
+                    // Cannot exit condition processing if we are in text mode.
+                    // Char count in the string-in-progress is split between `lit_buf`
+                    // (the literal segment we are currently building) and `pattern_parts`
+                    // (segments already flushed). The `-1` accounts for the opening `"`.
+                    let text_chars: usize = lit_buf.chars().count()
+                        + pattern_parts
+                            .iter()
+                            .map(|p| match p {
+                                PatternPart::Literal(s) => s.chars().count(),
+                                PatternPart::AnySequence => 1,
+                            })
+                            .sum::<usize>();
                     return Err(FilterError {
-                        char_position: *index.borrow() - value.chars().count() - 1,
+                        char_position: *index.borrow() - text_chars - 1,
                         error_code: FilterErrorCode::UnclosedQuote,
                     });
                 }
-                append_value(&mut value, was_string, &mut tokens, *index.borrow(), offset)?;
+                append_value(&mut value, &mut pattern_parts, was_string, &mut tokens, *index.borrow(), offset)?;
                 *index.borrow_mut() -= 1;
                 break;
             }
@@ -562,15 +618,23 @@ fn condition_lexer_index(
                             match c {
                                 '"' => {
                                     parser_log!("COND Read a QUOTE - Exit text mode"; depth);
-                                    append_value(&mut value, true, &mut tokens, *index.borrow(), offset)?;
+                                    flush_lit_buf(&mut lit_buf, &mut pattern_parts);
+                                    append_value(
+                                        &mut value,
+                                        &mut pattern_parts,
+                                        true,
+                                        &mut tokens,
+                                        *index.borrow(),
+                                        offset,
+                                    )?;
                                     break;
                                 }
                                 '#' => {
                                     *index.borrow_mut() += 1;
                                     match read_char_at_index(&index, &input_chars, depth) {
-                                        Some('"') => value.push('"'),
-                                        Some('%') => value.push('%'),
-                                        Some('#') => value.push('#'),
+                                        Some('"') => lit_buf.push('"'),
+                                        Some('%') => lit_buf.push('%'),
+                                        Some('#') => lit_buf.push('#'),
                                         _ => {
                                             return Err(FilterError {
                                                 char_position: *index.borrow() - 1 + offset,
@@ -586,7 +650,11 @@ fn condition_lexer_index(
                                         Some(Token::Operator(pt)) if pt.token == ComparisonOperator::LIKE
                                     );
                                     if is_like {
-                                        value.push('%');
+                                        flush_lit_buf(&mut lit_buf, &mut pattern_parts);
+                                        // collapse consecutive AnySequence into one
+                                        if !matches!(pattern_parts.last(), Some(PatternPart::AnySequence)) {
+                                            pattern_parts.push(PatternPart::AnySequence);
+                                        }
                                     } else {
                                         return Err(FilterError {
                                             char_position: *index.borrow() + offset,
@@ -594,7 +662,7 @@ fn condition_lexer_index(
                                         });
                                     }
                                 }
-                                other => value.push(other),
+                                other => lit_buf.push(other),
                             }
                         } else if c == '"' {
                             text_mode = true;
@@ -848,16 +916,51 @@ fn append_attribute(
     Ok(())
 }
 
+/// Flush the in-progress literal buffer into `pattern_parts` as a new `Literal`
+/// segment, if non-empty. No-op when empty. The buffer is cleared in any case.
+fn flush_lit_buf(lit_buf: &mut String, pattern_parts: &mut Vec<PatternPart>) {
+    if !lit_buf.is_empty() {
+        pattern_parts.push(PatternPart::Literal(std::mem::take(lit_buf)));
+    }
+}
+
 fn append_value(
     value: &mut String,
+    pattern_parts: &mut Vec<PatternPart>,
     is_string: bool,
     tokens: &mut Vec<Token>,
     index: usize,
     offset: usize,
 ) -> Result<(), FilterError> {
     let lexeme = if is_string {
-        let n = value.chars().count();
-        Token::ValueString(PositionalToken::new(value.clone(), index + offset - n))
+        // Total char count of the value as it appeared in the source (without quotes).
+        let n: usize = pattern_parts
+            .iter()
+            .map(|p| match p {
+                PatternPart::Literal(s) => s.chars().count(),
+                PatternPart::AnySequence => 1,
+            })
+            .sum();
+
+        // Use ValuePattern only when the operator we just emitted is LIKE.
+        // For every other operator, bare `%` is forbidden upstream, so
+        // `pattern_parts` contains at most one `Literal` segment.
+        let is_like = matches!(
+            tokens.last(),
+            Some(Token::Operator(pt)) if pt.token == ComparisonOperator::LIKE
+        );
+        if is_like {
+            Token::ValuePattern(PositionalToken::new(std::mem::take(pattern_parts), index + offset - n))
+        } else {
+            let flat: String = pattern_parts
+                .drain(..)
+                .map(|p| match p {
+                    PatternPart::Literal(s) => s,
+                    PatternPart::AnySequence => String::from("%"),
+                })
+                .collect();
+            Token::ValueString(PositionalToken::new(flat, index + offset - n))
+        }
     } else if value == TRUE {
         Token::ValueBool(PositionalToken::new(true, index + offset - TRUE.len()))
     } else if value == FALSE {
@@ -883,7 +986,7 @@ mod tests {
     //cargo test --color=always --bin document-server expression_filter_parser::tests   -- --show-output
 
     use crate::filter::filter_lexer::{
-        lex3, FilterErrorCode, LogicalOperator, PositionalToken, Token, TokenSlice,
+        lex3, FilterErrorCode, LogicalOperator, PatternPart, PositionalToken, Token, TokenSlice,
     };
     use crate::filter::tests::init_logger;
     use crate::filter::ComparisonOperator;
@@ -1043,7 +1146,10 @@ mod tests {
             Token::LogicalOpen(PositionalToken::new((), pos[10])),
             Token::Attribute(PositionalToken::new("attribut3".to_string(), pos[11])),
             Token::Operator(PositionalToken::new(ComparisonOperator::LIKE, pos[12])),
-            Token::ValueString(PositionalToken::new("den%".to_string(), pos[13])),
+            Token::ValuePattern(PositionalToken::new(
+                vec![PatternPart::Literal("den".to_string()), PatternPart::AnySequence],
+                pos[13],
+            )),
             Token::LogicalClose(PositionalToken::new((), pos[14])),
             //Token::LogicalClose(PositionalToken::new((), input.chars().count() + 1)),
         ];
@@ -1137,7 +1243,10 @@ mod tests {
             Token::LogicalOpen(PositionalToken::new((), pos[14])),
             Token::Attribute(PositionalToken::new("attribut3".to_string(), pos[15])),
             Token::Operator(PositionalToken::new(ComparisonOperator::LIKE, pos[16])),
-            Token::ValueString(PositionalToken::new("den%".to_string(), pos[17])),
+            Token::ValuePattern(PositionalToken::new(
+                vec![PatternPart::Literal("den".to_string()), PatternPart::AnySequence],
+                pos[17],
+            )),
             Token::LogicalClose(PositionalToken::new((), pos[18])),
             //Token::LogicalClose(PositionalToken::new((), input.chars().count() + 1)), // fixed pos value
         ];
@@ -1168,7 +1277,10 @@ mod tests {
             Token::BinaryLogicalOperator(PositionalToken::new(LogicalOperator::OR, pos[9])),
             Token::Attribute(PositionalToken::new("attribut3".to_string(), pos[10])),
             Token::Operator(PositionalToken::new(ComparisonOperator::LIKE, pos[11])),
-            Token::ValueString(PositionalToken::new("den%".to_string(), pos[12])),
+            Token::ValuePattern(PositionalToken::new(
+                vec![PatternPart::Literal("den".to_string()), PatternPart::AnySequence],
+                pos[12],
+            )),
             Token::LogicalClose(PositionalToken::new((), pos[13])),
             Token::LogicalClose(PositionalToken::new((), pos[14])),
             //Token::LogicalClose(PositionalToken::new((), input.chars().count() + 1)), // fixed pos value
@@ -1326,7 +1438,10 @@ mod tests {
             Token::LogicalOpen(PositionalToken::new((), pos[10])),
             Token::Attribute(PositionalToken::new("attribut3".to_string(), pos[11])),
             Token::Operator(PositionalToken::new(ComparisonOperator::LIKE, pos[12])),
-            Token::ValueString(PositionalToken::new("den%".to_string(), pos[13])),
+            Token::ValuePattern(PositionalToken::new(
+                vec![PatternPart::Literal("den".to_string()), PatternPart::AnySequence],
+                pos[13],
+            )),
             Token::LogicalClose(PositionalToken::new((), pos[14])),
             //Token::LogicalClose(PositionalToken::new((), input.chars().count() + 1)), // fixed pos value
         ];

--- a/document-server/src/filter/mod.rs
+++ b/document-server/src/filter/mod.rs
@@ -1,5 +1,5 @@
-use crate::filter::filter_ast::{parse_tokens, ComparisonOperator, FilterCondition, FilterExpressionAST};
-use crate::filter::filter_lexer::{lex3, FilterError};
+use crate::filter::filter_ast::{parse_tokens, ComparisonOperator, FilterCondition, FilterExpressionAST, FilterValue};
+use crate::filter::filter_lexer::{lex3, FilterError, PatternPart};
 use crate::filter::filter_normalizer::normalize_lexeme;
 use crate::parser_log;
 use commons_error::*;
@@ -38,7 +38,15 @@ pub(crate) fn to_sql_form(filter_expression: &FilterExpressionAST) -> Result<Str
                 ComparisonOperator::LIKE => "LIKE",
             };
 
-            let s = format!("({} {} {})", attribute, sql_op, value);
+            // For a LIKE pattern, render `AnySequence` as the SQL wildcard `%` and
+            // emit literal segments verbatim. Proper escaping of literal `%`/`_`
+            // (with an `ESCAPE` clause) is a separate concern — see F0001.
+            let value_sql = match value {
+                FilterValue::ValuePattern(parts) => render_pattern_for_sql(parts),
+                other => format!("{}", other),
+            };
+
+            let s = format!("({} {} {})", attribute, sql_op, value_sql);
             content.push_str(&s);
         }
         FilterExpressionAST::Logical { operator, leaves } => {
@@ -57,6 +65,17 @@ pub(crate) fn to_sql_form(filter_expression: &FilterExpressionAST) -> Result<Str
         }
     }
     Ok(content)
+}
+
+fn render_pattern_for_sql(parts: &[PatternPart]) -> String {
+    let mut s = String::new();
+    for part in parts {
+        match part {
+            PatternPart::Literal(lit) => s.push_str(lit),
+            PatternPart::AnySequence => s.push('%'),
+        }
+    }
+    s
 }
 
 #[cfg(test)]
@@ -302,13 +321,26 @@ mod tests {
     #[test]
     pub fn it_f0001_012_like_wildcard_regression() {
         init_logger();
-        assert_canonical(r#"(name LIKE "den%")"#, "[name<LIKE>den%]");
+        // Bare `%` is the AnySequence wildcard, rendered `\%\` in the canonical form.
+        // AST: ValuePattern([Literal("den"), AnySequence])
+        assert_canonical(r#"(name LIKE "den%")"#, r"[name<LIKE>den\%\]");
     }
 
     #[test]
     pub fn it_f0001_013_literal_percent_inside_like() {
         init_logger();
+        // Escaped `#%` is consumed as a literal percent inside the Literal segment.
+        // AST: ValuePattern([Literal("50%")])
+        // Distinct from `LIKE "50%"` (which would render as `50\%\`).
         assert_canonical(r#"(code LIKE "50#%")"#, "[code<LIKE>50%]");
+    }
+
+    #[test]
+    pub fn it_f0001_013b_like_wildcard_surrounding_literals() {
+        init_logger();
+        // Leading wildcard, embedded escaped percent, trailing wildcard.
+        // AST: ValuePattern([AnySequence, Literal("foo%bar"), AnySequence])
+        assert_canonical(r#"(name LIKE "%foo#%bar%")"#, r"[name<LIKE>\%\foo%bar\%\]");
     }
 
     #[test]

--- a/wiki/Command line.md
+++ b/wiki/Command line.md
@@ -260,13 +260,22 @@ Tags deleted from item with id : 459
 **Search items [session]**
 
 ```bash
-dk item search 
-    -f --filter "file_name=*planet*"
+dk item search
+    -f --filter "(file_name LIKE \"planet%\") AND (category == \"astro\")"
 ```
 
 id:459   planet.pdf       category:astro       email_number:789845
 
-> List all the item matching the properties (**todo**)
+> List all items whose properties match the filter. The filter follows the
+> Doka Filter Syntax (DFS) — see `_ai/specs/filter-syntax.md`.
+>
+> Quick reference:
+> - Conditions: `attribute <op> value`, with `<op>` ∈ `== != < <= > >= LIKE`.
+> - String values use double quotes. Inside a string, the characters `"`, `%`
+>   and `#` must be escaped with a leading `#`: `#"`, `#%`, `##`.
+> - In a `LIKE` value, a bare `%` is the wildcard (any sequence). Use `#%` for
+>   a literal percent. A bare `%` is rejected anywhere else.
+> - Combine with `AND` / `OR` and group with `( ... )`.
 
 ---
 

--- a/wiki/doka user guide.md
+++ b/wiki/doka user guide.md
@@ -26,24 +26,40 @@ doka-cli item create -n item3 -p "(my_email:t@t.com)(tag2:blabla)"
 doka-cli item tag -id 2 -u "(to:1:link)"
 ````
 
-### ~~Search items~~
+### Search items
 
 ```bash
-doka-cli item search  
-	-f "(lastname LIKE a%) OR (+postal_code = 34500 AND lastname LIKE %h%)" 
-	-s "lastname desc"
+doka-cli item search
+    -f "(lastname LIKE \"a%\") OR (postal_code == 34500 AND lastname LIKE \"%h%\")"
+    -s "lastname desc"
 ```
 
-> ~~Don't use simple or double quote with text operator.~~
-> ~~Use a "+" sign in the front of very selective condition~~
+The filter follows the Doka Filter Syntax (DFS). Rules:
 
-> Inside a quoted string value, the characters `"`, `%` and `#` must be escaped with a leading `#`:
-> `#"` → `"`, `#%` → `%`, `##` → `#`. Bare `%` is still allowed inside a `LIKE` value where it
-> keeps its wildcard meaning.
+- Conditions are `attribute <op> value` with `<op>` ∈ `== != < <= > >= LIKE`.
+  Use `==`, not `=`. A single `=` is rejected.
+- String values are always double-quoted. Numbers and `TRUE` / `FALSE` are not.
+- Inside a quoted string, the characters `"`, `%` and `#` must be escaped with
+  a leading `#`: `#"` → `"`, `#%` → `%`, `##` → `#`.
+- In a `LIKE` value, a bare `%` is the wildcard (any sequence of characters).
+  Use `#%` for a literal percent. A bare `%` outside a `LIKE` value, or any
+  unescaped `#` / `"` / `%`, is a syntax error (`InvalidEscapeSequence`).
+- Combine with `AND` / `OR` (case-insensitive) and group with `( ... )`.
+  `AND` binds tighter than `OR`; use parentheses to override.
+
+Example combining escapes:
 
 ```bash
 doka-cli item search -f "(category == \"super #\"extra#\" player\") AND (note == \"see paragraph ##6\")"
 ```
+
+The parser receives:
+
+```
+(category == "super #"extra#" player") AND (note == "see paragraph ##6")
+```
+
+and stores `super "extra" player` and `see paragraph #6` as the two values.
 
 ### ~~Upload a file~~ 
 


### PR DESCRIPTION
- Implements F0001
- Replaces flat ValueString in LIKE contexts with ValuePattern(Vec<PatternPart>) so LIKE "den%" (wildcard) and LIKE "den#%" (literal %) no longer collapse to the same AST
- Canonical form renders wildcards as \%\ to keep the distinction visible
- Lexer builds the structured pattern directly; to_sql_form emits AnySequence as SQL %
- Tests: 91/91 filter, 112/112 doc-server
- Out of scope: ESCAPE clause for literal %/_ in LIKE segments