### PR TITLE
fix(document-service): Better escaping in the sql generation

### DIFF
--- a/_ai/F0002-sql-escaping/F0002.md
+++ b/_ai/F0002-sql-escaping/F0002.md
@@ -1,0 +1,80 @@
+
+```yaml
+id: SQL-ESCAPING
+flow-id: DOKA-ITEM-SEARCH
+type: fix
+status: draft
+language: Rust
+related_entities:
+  - ITEM-FILTER
+related_tests:
+  - IT-ITEM-FILTER
+```
+
+# Goals
+SQL produced from any legal DFS AST must be syntactically valid and must
+preserve wildcard vs literal `%` / `_` semantics in `LIKE`.
+
+The current emitters incorrectly inline the value verbatim: a `'` in the value breaks the query, and a
+literal `%` (from `#%`) is indistinguishable from a `LIKE` wildcard.
+
+# Inputs
+- A valid `FilterCondition` whose value can contain any character — including
+  `'`, `%`, `_`, `\`, `"`, `#`.
+
+# Outputs
+- A PostgreSQL fragment in which every `'` of the value is doubled.
+- For `LIKE`, literal `%`, `_` and `\` are escaped with `\` and the clause carries `ESCAPE '\'`; wildcards are emitted bare.
+
+# Preconditions
+- Well formed AST.
+
+# Postconditions
+- No legal AST can produce malformed SQL.
+- The AST conditions generates SQL conditions that complies with PostgreSQL 9.1 standards.
+
+# Business rules
+
+1. **`'` doubling.** In every SQL string literal emitted from a DFS value,
+   every `'` of the value is doubled (`'` → `''`). This is the only
+   escaping needed for SQL-string syntax.
+
+2. **Non-`LIKE` operators.** For `=`, `<>`, `>`, `>=`, `<`, `<=`, the
+   characters `%`, `_`, `\`, `"`, `#` have no SQL meaning inside a
+   single-quoted literal — pass them through unchanged.
+
+3. **`LIKE` emission.** The emitter renders `AnySequence` as `%` and emits 
+   each `Literal` part with `%`, `_`, `\` prefixed by
+   `\`. 
+   The clause is `… LIKE 'pattern' ESCAPE '\'`. The `ESCAPE` clause
+   may be omitted when no `Literal` part contained `%`, `_` or `\` — that
+   is purely cosmetic.
+
+4. **Backslash in non-`LIKE` strings.** Under
+   `standard_conforming_strings = on`, `\` inside `'…'` is a plain
+   character. Pass through unchanged.
+
+# Errors
+No new `FilterErrorCode` variant. SQL escaping is purely an emission
+concern — every legal AST produces legal SQL after F0002.
+
+# Examples — canonical form → SQL fragment
+
+The "Canonical form" column is what `to_canonical_form` prints today; the
+"SQL fragment" column is what it requires the value-side of the SQL
+condition to look like. The real call site wraps it in
+`unaccent_lower((tv.value_string)::text) … unaccent_lower('…')` — the
+fragments below show only the operator + value-literal part.
+
+| DFS input                          | Canonical form                       | SQL fragment                                |
+|------------------------------------|--------------------------------------|---------------------------------------------|
+| `name == "denis"`                  | `[name<EQ>denis]`                    | `= 'denis'`                                 |
+| `name == "d'arc"`                  | `[name<EQ>d'arc]`                    | `= 'd''arc'`                                |
+| `team == "L'#"équipe#""`           | `[team<EQ>L'"équipe"]`               | `= 'L''"équipe"'`                           |
+| `note == "100#%"`                  | `[note<EQ>100%]`                     | `= '100%'`                                  |
+| `comment == "see ##6"`             | `[comment<EQ>see #6]`                | `= 'see #6'`                                |
+| `name LIKE "den%"`                 | `[name<LIKE>den\%\]`                   | `LIKE 'den%'`                               |
+| `name LIKE "L'équipe de moi%"`     | `[name<LIKE>L'équipe de moi\%\]`       | `LIKE 'L''équipe de moi%'`                  |
+| `code LIKE "50#%"`                 | `[code<LIKE>50%]`                    | `LIKE '50\%' ESCAPE '\'`                    |
+| `code LIKE "##_x_%"`               | `[code<LIKE>#_x_\%\]`                  | `LIKE '#\_x\_%' ESCAPE '\'`                 |
+| `path LIKE "C:\path%"`             | `[path<LIKE>C:\path\%\]`               | `LIKE 'C:\\path%' ESCAPE '\'`               |

--- a/_ai/F0002-sql-escaping/unit_tests_sql_escaping.md
+++ b/_ai/F0002-sql-escaping/unit_tests_sql_escaping.md
@@ -1,0 +1,222 @@
+
+```yaml
+id: IT-F0002
+title: Integration tests — SQL Escaping (DFS → PostgreSQL)
+type: integration-test
+status: draft
+target_flow: DOKA-ITEM-SEARCH
+related_fix: F0002
+naming_prefix: IT-F0002
+language: rust
+```
+
+# Coverage goal
+Validate that the SQL fragment emitted from a DFS `FilterCondition` is
+syntactically valid PostgreSQL (9.1+) and preserves the wildcard vs
+literal semantics of `%` and `_` in `LIKE`, as specified in
+[F0002.md](F0002.md). The tests check:
+
+- doubling of `'` in every emitted SQL string literal;
+- pass-through of `%`, `_`, `\`, `"`, `#` inside non-`LIKE` literals
+  (`standard_conforming_strings = on`);
+- emission of `LIKE` patterns: `AnySequence` → bare `%`, literal
+  `%` / `_` / `\` → `\%` / `\_` / `\\` plus an `ESCAPE '\'` clause;
+- omission of the `ESCAPE '\'` clause when no literal escape character
+  is present (purely cosmetic);
+- regression on plain values that need no escaping.
+
+System under test: the SQL emission path in
+[`document-server/src/filter/mod.rs`](../../document-server/src/filter/mod.rs)
+(the function that turns a `FilterCondition` / `ValuePattern` into the
+operator + value-literal SQL fragment). The surrounding
+`unaccent_lower((tv.value_string)::text) … unaccent_lower('…')` wrapper
+is out of scope — each assertion targets only the operator + value-literal
+substring, as in the example table of F0002.md.
+
+# Test cases
+
+## TC-F0002-001 — Single-quote doubling on `=`
+Given:
+- DFS input: `name == "d'arc"`
+- canonical form (parser output): `[name<EQ>d'arc]`
+
+When:
+- the condition is emitted as SQL
+
+Then:
+- emitted SQL fragment: `= 'd''arc'`
+- the value's `'` is doubled exactly once
+- no `ESCAPE` clause is present (operator is `=`, not `LIKE`)
+
+## TC-F0002-002 — Special characters pass through on non-`LIKE`
+Given:
+- DFS input: `team == "L'#"équipe#""`
+- canonical form (parser output): `[team<EQ>L'"équipe"]`
+
+When:
+- the condition is emitted as SQL
+
+Then:
+- emitted SQL fragment: `= 'L''"équipe"'`
+- the embedded `"` characters are passed through unchanged
+- the `'` is doubled per rule 1
+- `#` does **not** appear in the fragment (it was consumed by the DFS
+  parser as an escape introducer, not by the SQL emitter)
+
+Sibling assertion (same rule, backslash branch — rule 4):
+- DFS input: `path == "C:\tmp"` with canonical form `[path<EQ>C:\tmp]`
+- emitted SQL fragment: `= 'C:\tmp'`
+- `\` is preserved verbatim (standard-conforming strings)
+
+## TC-F0002-003 — `LIKE` with a pure wildcard, no `ESCAPE` clause
+Given:
+- DFS input: `name LIKE "den%"`
+- canonical form (parser output): `[name<LIKE>den\%\]`
+- AST value: `ValuePattern([Literal("den"), AnySequence])`
+
+When:
+- the condition is emitted as SQL
+
+Then:
+- emitted SQL fragment: `LIKE 'den%'`
+- the `%` is emitted bare (it is `AnySequence`, not a literal)
+- the `ESCAPE '\'` clause is **omitted** — no `Literal` part contained
+  `%`, `_` or `\`, so the clause is cosmetically unnecessary (rule 3)
+
+## TC-F0002-004 — `LIKE` with a literal `%` requiring `ESCAPE '\'`
+Given:
+- DFS input: `code LIKE "50#%"`
+- canonical form (parser output): `[code<LIKE>50%]`
+- AST value: `ValuePattern([Literal("50%")])`
+
+When:
+- the condition is emitted as SQL
+
+Then:
+- emitted SQL fragment: `LIKE '50\%' ESCAPE '\'`
+- the literal `%` from the `Literal` part is prefixed with `\`
+- the `ESCAPE '\'` clause is present (rule 3, main branch)
+
+## TC-F0002-005 — `LIKE` mixing wildcards, literal `'`, and a trailing wildcard
+Given:
+- DFS input: `name LIKE "L'équipe de moi%"`
+- canonical form (parser output): `[name<LIKE>L'équipe de moi\%\]`
+- AST value: `ValuePattern([Literal("L'équipe de moi"), AnySequence])`
+
+When:
+- the condition is emitted as SQL
+
+Then:
+- emitted SQL fragment: `LIKE 'L''équipe de moi%'`
+- the `'` inside the `Literal` part is doubled (rule 1 applies inside
+  `LIKE` patterns just as it does elsewhere)
+- the trailing `%` is emitted bare (it is `AnySequence`)
+- the `ESCAPE '\'` clause is **omitted** — the `Literal` part contained
+  no `%`, `_` or `\`
+
+## TC-F0002-006 — `LIKE` with literal `_` (and `%` wildcard)
+Given:
+- DFS input: `code LIKE "##_x_%"`
+- canonical form (parser output): `[code<LIKE>#_x_\%\]`
+- AST value: `ValuePattern([Literal("#_x_"), AnySequence])`
+
+When:
+- the condition is emitted as SQL
+
+Then:
+- emitted SQL fragment: `LIKE '#\_x\_%' ESCAPE '\'`
+- each literal `_` from the `Literal` part is prefixed with `\`
+- the trailing `%` is `AnySequence` and is emitted bare
+- the `ESCAPE '\'` clause is present (rule 3, main branch)
+
+## TC-F0002-007 — `LIKE` with literal `\` (backslash doubling)
+Given:
+- DFS input: `path LIKE "C:\path%"`
+- canonical form (parser output): `[path<LIKE>C:\path\%\]`
+- AST value: `ValuePattern([Literal("C:\path"), AnySequence])`
+
+When:
+- the condition is emitted as SQL
+
+Then:
+- emitted SQL fragment: `LIKE 'C:\\path%' ESCAPE '\'`
+- the literal `\` is doubled to `\\` inside the `LIKE` pattern (rule 3)
+- this is the **opposite** of rule 4: inside a non-`LIKE` literal, `\`
+  passes through unchanged; inside `LIKE`, `\` must be escaped
+- the `ESCAPE '\'` clause is present
+
+## TC-F0002-008 — `!=` operator with `'` doubling
+Given:
+- DFS input: `name != "d'arc"`
+- canonical form (parser output): `[name<NEQ>d'arc]`
+
+When:
+- the condition is emitted as SQL
+
+Then:
+- emitted SQL fragment: `<> 'd''arc'`
+- `'` doubling (rule 1) is applied identically across the full non-`LIKE`
+  operator family (`=`, `<>`, `>`, `>=`, `<`, `<=`)
+- no `ESCAPE` clause (not a `LIKE` operator)
+
+## TC-F0002-009 — Non-`LIKE` value mixing `'` and pass-through `%`
+Given:
+- DFS input: `note == "ain't 100#%"`
+- canonical form (parser output): `[note<EQ>ain't 100%]`
+
+When:
+- the condition is emitted as SQL
+
+Then:
+- emitted SQL fragment: `= 'ain''t 100%'`
+- the `'` is doubled (rule 1)
+- the `%` is **not** escaped — it has no SQL meaning inside a
+  single-quoted literal under `=` (rule 2)
+- no `ESCAPE` clause is emitted (it is meaningful only with `LIKE`)
+
+## TC-F0002-010 — `LIKE` combining `'` doubling, literal `%`, and `ESCAPE`
+Given:
+- DFS input: `note LIKE "L'eq 50#%"`
+- canonical form (parser output): `[note<LIKE>L'eq 50%]`
+- AST value: `ValuePattern([Literal("L'eq 50%")])`
+
+When:
+- the condition is emitted as SQL
+
+Then:
+- emitted SQL fragment: `LIKE 'L''eq 50\%' ESCAPE '\'`
+- the `'` is doubled (rule 1)
+- the literal `%` is prefixed with `\` (rule 3)
+- the `ESCAPE '\'` clause is present
+- this case exercises rules 1 and 3 simultaneously, which none of the
+  earlier `LIKE` cases does
+
+
+## TC-F0002-011 — Boundary: empty string literal
+Given:
+- DFS input: `note == ""`
+- canonical form (parser output): `[note<EQ>]`
+
+When:
+- the condition is emitted as SQL
+
+Then:
+- emitted SQL fragment: `= ''`
+- the emitter produces a syntactically valid empty SQL string literal
+  (two single quotes, not a bare `=` or a doubled `''''`)
+
+## TC-F0002-013 — Composite `AND` with escaping on each side
+Given:
+- DFS input: `(name == "d'arc") AND (code LIKE "50#%")`
+- canonical form (parser output):
+  `([name<EQ>d'arc]AND[code<LIKE>50%])`
+
+When:
+- the composite expression is emitted as SQL
+
+Then:
+- the SQL fragment contains both conditions joined by `AND`, each with
+  its own correctly escaped value-literal — for example:
+  `… = 'd''arc' AND … LIKE '50\%' ESCAPE '\'`
+- escaping is applied independently per `FilterCondition`; one branch's
+  `LIKE` rules do not leak into the other branch's `=` literal

--- a/document-server/src/filter/mod.rs
+++ b/document-server/src/filter/mod.rs
@@ -38,13 +38,7 @@ pub(crate) fn to_sql_form(filter_expression: &FilterExpressionAST) -> Result<Str
                 ComparisonOperator::LIKE => "LIKE",
             };
 
-            // For a LIKE pattern, render `AnySequence` as the SQL wildcard `%` and
-            // emit literal segments verbatim. Proper escaping of literal `%`/`_`
-            // (with an `ESCAPE` clause) is a separate concern — see F0001.
-            let value_sql = match value {
-                FilterValue::ValuePattern(parts) => render_pattern_for_sql(parts),
-                other => format!("{}", other),
-            };
+            let value_sql = to_sql_literal(value, operator);
 
             let s = format!("({} {} {})", attribute, sql_op, value_sql);
             content.push_str(&s);
@@ -67,15 +61,71 @@ pub(crate) fn to_sql_form(filter_expression: &FilterExpressionAST) -> Result<Str
     Ok(content)
 }
 
-fn render_pattern_for_sql(parts: &[PatternPart]) -> String {
-    let mut s = String::new();
-    for part in parts {
-        match part {
-            PatternPart::Literal(lit) => s.push_str(lit),
-            PatternPart::AnySequence => s.push('%'),
+/// Render a [`FilterValue`] as a SQL operand (operator + value-literal),
+/// applying the escaping rules of F0002.
+///
+/// Rules applied:
+/// - **Rule 1 — `'` doubling.** Every `'` inside a string value becomes `''`.
+/// - **Rule 2 — non-`LIKE` operators.** For `=`, `<>`, `>`, `>=`, `<`, `<=`,
+///   the characters `%`, `_`, `\`, `"`, `#` have no SQL meaning inside a
+///   single-quoted literal and pass through unchanged.
+/// - **Rule 3 — `LIKE` emission.** `AnySequence` is rendered as the bare
+///   `%` wildcard. Inside `Literal` parts, `%`, `_`, `\` are prefixed with
+///   `\`; if any such escape was emitted, the fragment is suffixed with
+///   ` ESCAPE '\'`.
+/// - **Rule 4 — backslash in non-`LIKE` strings.** Under
+///   `standard_conforming_strings = on`, `\` is a plain character and
+///   passes through unchanged.
+///
+/// Numbers and booleans are emitted as unquoted SQL atoms.
+///
+/// The returned string is ready to be substituted as-is into a SQL
+/// fragment of the form `<column> <op> <here>`.
+pub(crate) fn to_sql_literal(value: &FilterValue, operator: &ComparisonOperator) -> String {
+    if let (ComparisonOperator::LIKE, FilterValue::ValuePattern(parts)) = (operator, value) {
+        let mut body = String::new();
+        let mut needs_escape = false;
+        for part in parts {
+            match part {
+                PatternPart::AnySequence => body.push('%'),
+                PatternPart::Literal(lit) => {
+                    for ch in lit.chars() {
+                        match ch {
+                            '\'' => body.push_str("''"),
+                            '%' | '_' | '\\' => {
+                                body.push('\\');
+                                body.push(ch);
+                                needs_escape = true;
+                            }
+                            _ => body.push(ch),
+                        }
+                    }
+                }
+            }
+        }
+        return if needs_escape {
+            format!("'{}' ESCAPE '\\'", body)
+        } else {
+            format!("'{}'", body)
+        };
+    }
+
+    match value {
+        FilterValue::ValueString(s) => format!("'{}'", s.replace('\'', "''")),
+        FilterValue::ValueInt(i) => i.to_string(),
+        FilterValue::ValueBool(b) => (if *b { "TRUE" } else { "FALSE" }).to_string(),
+        FilterValue::ValuePattern(parts) => {
+            // Defensive: the parser only emits `ValuePattern` paired with `LIKE`.
+            let mut joined = String::new();
+            for part in parts {
+                match part {
+                    PatternPart::AnySequence => joined.push('%'),
+                    PatternPart::Literal(lit) => joined.push_str(lit),
+                }
+            }
+            format!("'{}'", joined.replace('\'', "''"))
         }
     }
-    s
 }
 
 #[cfg(test)]
@@ -341,6 +391,107 @@ mod tests {
         // Leading wildcard, embedded escaped percent, trailing wildcard.
         // AST: ValuePattern([AnySequence, Literal("foo%bar"), AnySequence])
         assert_canonical(r#"(name LIKE "%foo#%bar%")"#, r"[name<LIKE>\%\foo%bar\%\]");
+    }
+
+    // === IT-F0002 : SQL escaping (DFS → PostgreSQL) ===
+
+    fn assert_sql(input: &str, expected: &str) {
+        match analyse_expression(input) {
+            Ok(ast) => {
+                let sql = super::to_sql_form(ast.as_ref()).unwrap();
+                assert_eq!(expected, &sql, "input `{}`", input);
+            }
+            Err(e) => panic!("Unexpected error for `{}`: {}", input, e.human_error_message()),
+        }
+    }
+
+    #[test]
+    pub fn it_f0002_001_quote_doubling_eq() {
+        init_logger();
+        assert_sql(r#"(name == "d'arc")"#, "(name = 'd''arc')");
+    }
+
+    #[test]
+    pub fn it_f0002_002_special_chars_pass_through() {
+        init_logger();
+        // `#"` is the DFS escape for `"`; after parsing the value is L'"équipe"
+        assert_sql(r#"(team == "L'#"équipe#"")"#, r#"(team = 'L''"équipe"')"#);
+    }
+
+    #[test]
+    pub fn it_f0002_002b_backslash_pass_through_non_like() {
+        init_logger();
+        // Rule 4: `\` is a plain character inside non-LIKE literals.
+        assert_sql(r#"(path == "C:\tmp")"#, r"(path = 'C:\tmp')");
+    }
+
+    #[test]
+    pub fn it_f0002_003_like_pure_wildcard_no_escape() {
+        init_logger();
+        assert_sql(r#"(name LIKE "den%")"#, "(name LIKE 'den%')");
+    }
+
+    #[test]
+    pub fn it_f0002_004_like_literal_percent_with_escape() {
+        init_logger();
+        assert_sql(r#"(code LIKE "50#%")"#, r"(code LIKE '50\%' ESCAPE '\')");
+    }
+
+    #[test]
+    pub fn it_f0002_005_like_quote_and_trailing_wildcard() {
+        init_logger();
+        assert_sql(r#"(name LIKE "L'équipe de moi%")"#, r"(name LIKE 'L''équipe de moi%')");
+    }
+
+    #[test]
+    pub fn it_f0002_006_like_literal_underscore_with_escape() {
+        init_logger();
+        assert_sql(r###"(code LIKE "##_x_%")"###, r"(code LIKE '#\_x\_%' ESCAPE '\')");
+    }
+
+    #[test]
+    pub fn it_f0002_007_like_literal_backslash_with_escape() {
+        init_logger();
+        assert_sql(r#"(path LIKE "C:\path%")"#, r"(path LIKE 'C:\\path%' ESCAPE '\')");
+    }
+
+    #[test]
+    pub fn it_f0002_008_neq_with_quote_doubling() {
+        init_logger();
+        assert_sql(r#"(name != "d'arc")"#, "(name <> 'd''arc')");
+    }
+
+    #[test]
+    pub fn it_f0002_009_non_like_mixed_quote_and_percent() {
+        init_logger();
+        assert_sql(r#"(note == "ain't 100#%")"#, "(note = 'ain''t 100%')");
+    }
+
+    #[test]
+    pub fn it_f0002_010_like_quote_percent_and_escape() {
+        init_logger();
+        assert_sql(r#"(note LIKE "L'eq 50#%")"#, r"(note LIKE 'L''eq 50\%' ESCAPE '\')");
+    }
+
+    #[test]
+    pub fn it_f0002_011_plain_value_regression() {
+        init_logger();
+        assert_sql(r#"(name == "denis")"#, "(name = 'denis')");
+    }
+
+    #[test]
+    pub fn it_f0002_012_empty_string_literal() {
+        init_logger();
+        assert_sql(r#"(note == "")"#, "(note = '')");
+    }
+
+    #[test]
+    pub fn it_f0002_013_composite_and_with_escaping_each_side() {
+        init_logger();
+        assert_sql(
+            r#"(name == "d'arc") AND (code LIKE "50#%")"#,
+            r"((name = 'd''arc') AND (code LIKE '50\%' ESCAPE '\'))",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## fix(filter): apply F0002 SQL escaping to emitted value-literals

### Summary
SQL fragments produced from a DFS `FilterCondition` were inlining values verbatim — a `'` in a value broke the query, and a literal `%` (from `#%`) was indistinguishable from a `LIKE` wildcard. This PR makes the SQL emitter compliant with F0002.

### Changes
- **`document-server/src/filter/mod.rs`**
  - New `to_sql_literal(value, operator)` helper, with rustdoc spelling out the four F0002 rules:
    1. `'` doubled in every emitted SQL string literal.
    2. `%`, `_`, `\`, `"`, `#` pass through unchanged in non-`LIKE` literals.
    3. `LIKE` patterns render `AnySequence` as bare `%`, escape literal `%` / `_` / `\` with `\`, and append ` ESCAPE '\'` when any such escape was emitted.
    4. `\` passes through unchanged in non-`LIKE` strings (standard-conforming strings).
  - `to_sql_form` delegates value-side escaping to the new helper; the old `render_pattern_for_sql` is removed.

### Tests
- 14 new `it_f0002_*` cases in `document-server/src/filter/mod.rs`, mirroring [`_ai/F0002-sql-escaping/unit_tests_sql_escaping.md`](_ai/F0002-sql-escaping/unit_tests_sql_escaping.md):

| #     | Rule(s)        | Example input → emitted fragment                                  |
|-------|----------------|-------------------------------------------------------------------|
| 001   | 1              | `name == "d'arc"` → `= 'd''arc'`                                  |
| 002   | 1, 2           | `team == "L'#"équipe#""` → `= 'L''"équipe"'`                      |
| 002b  | 4              | `path == "C:\tmp"` → `= 'C:\tmp'`                                 |
| 003   | 3 (cosmetic)   | `name LIKE "den%"` → `LIKE 'den%'`                                |
| 004   | 3              | `code LIKE "50#%"` → `LIKE '50\%' ESCAPE '\'`                     |
| 005   | 1 + 3          | `name LIKE "L'équipe de moi%"` → `LIKE 'L''équipe de moi%'`       |
| 006   | 3 (`_`)        | `code LIKE "##_x_%"` → `LIKE '#\_x\_%' ESCAPE '\'`                |
| 007   | 3 (`\`)        | `path LIKE "C:\path%"` → `LIKE 'C:\\path%' ESCAPE '\'`            |
| 008   | 1, 2           | `name != "d'arc"` → `<> 'd''arc'`                                 |
| 009   | 1, 2           | `note == "ain't 100#%"` → `= 'ain''t 100%'`                       |
| 010   | 1 + 3          | `note LIKE "L'eq 50#%"` → `LIKE 'L''eq 50\%' ESCAPE '\'`          |
| 011   | regression     | `name == "denis"` → `= 'denis'`                                   |
| 012   | boundary       | `note == ""` → `= ''`                                             |
| 013   | composite      | `… AND …` with independent escaping on each side                  |

`cargo test --bin document-server filter::` → **99 passed, 0 failed** (14 new + 85 pre-existing).

### Out of scope
[`document-server/src/engine/generator.rs:230`](document-server/src/engine/generator.rs:230) still wraps values via `unaccent_lower('{value}')` using `FilterValue`'s `Display`, so the new escaping is not yet on the runtime SQL path. The F0002 spec explicitly scopes this PR to the emitter in `filter/mod.rs`; wiring `to_sql_literal` through the generator is a follow-up (needs care because `ESCAPE '\'` must sit *outside* `unaccent_lower(...)`).

### Spec docs
- [`_ai/F0002-sql-escaping/F0002.md`](_ai/F0002-sql-escaping/F0002.md) — rules + canonical→SQL example table
- [`_ai/F0002-sql-escaping/unit_tests_sql_escaping.md`](_ai/F0002-sql-escaping/unit_tests_sql_escaping.md) — 13 Given/When/Then test definitions