### PR TITLE
fix(B0001): Tolerate multi-space between attribute and operator in fi…

### DIFF
--- a/_ai/B0001-lexer-operator-space/B0001.md
+++ b/_ai/B0001-lexer-operator-space/B0001.md
@@ -1,0 +1,102 @@
+```yaml
+id: LEXER-OPERATOR-SPACE
+flow-id: DOKA-ITEM-SEARCH
+type: bug
+status: draft
+language: Rust
+related_entities:
+  - ITEM-SEARCH
+  - ITEM-FILTER
+related_tests:
+  - IT-B0001
+```
+
+# Summary
+
+The filter-expression lexer rejects requests whenever the user separates
+an attribute from its comparison operator with **more than one space**.
+The request is refused by the `document-server` with an **HTTP 400**
+(`UnknownFilterOperator`), even though it is syntactically equivalent to
+an accepted form.
+
+# Symptom
+
+| Filter passed via `doka-cli item search -f` | Result |
+|---|---|
+| `[val > 100]` (one space) | 200 OK |
+| `[val  > 100]` (two spaces) | **400 Bad Request** |
+| `[val   > 100]` (three or more spaces) | **400 Bad Request** |
+
+The error message returned by the server is *"Unknown filter operator
+at position N"*. The CLI does not relay it and only displays
+`400 - Http Client Error`, which makes the bug hard to diagnose on the
+user side.
+
+# Context
+
+The filter is sent as-is by `doka-cli` to the `document-server`, which
+tokenizes it through `condition_lexer_index` in
+[`document-server/src/filter/filter_lexer.rs`](../../document-server/src/filter/filter_lexer.rs).
+The lexer is a state machine (attribute → operator → value); state
+transitions are triggered by space characters.
+
+# Root cause
+
+The space handler in the **"operator being read"** branch does not check
+whether an operator was actually accumulated before attempting to
+validate it:
+
+- The first space after the attribute correctly closes the attribute
+  token and switches the state to "operator expected".
+- The second space, encountered before any operator character has been
+  read, attempts to validate an empty operator string, which produces
+  an `UnknownFilterOperator` error.
+
+A neighboring branch — the space handler in the "value being read"
+state — already handles this case correctly by skipping spaces as long
+as no value character has been read yet. The same logic is missing on
+the operator side. The bug therefore manifests **only** between the
+attribute and its operator, never between the operator and its value.
+
+# User impact
+
+- Expressions that are copy-pasted or formatted with multiple spaces
+  for readability are rejected without a useful CLI-side message.
+- The user wrongly suspects a tag-type issue or a syntax issue
+  (parentheses, quotes, operator), which derails the diagnosis. The
+  real-world case observed in the field is exactly this one.
+- No risk of corruption or leakage: the request is cleanly refused by
+  the server, but the user experience is degraded.
+
+# Scope
+
+- **Affected**: `document-server`, filter-expression lexer.
+- **Not affected**: grammar, normalization, SQL generation, semantic
+  validation of tags. The fix is purely local to the space handling
+  inside the "operator" branch.
+
+# Fix direction
+
+Align the "operator" branch with the "value" branch: if no operator
+character has been accumulated yet when a space is encountered, skip it
+and continue the loop instead of validating an empty operator.
+
+This change **does not** introduce any new character set or grammar
+rule — it simply tolerates multiple spaces in a place where a single
+one is already accepted, mirroring the rest of the lexer.
+
+# Tests to add
+
+- `val  > 100` (two spaces between attribute and operator) → success.
+- `val   >=   100` (multiple spaces on both sides) → success.
+- Combinations with operators `==`, `!=`, `<`, `<=`, `LIKE`.
+- Existing errors must still fire for actually invalid expressions
+  (unknown operator, empty attribute).
+
+# Side observation
+
+The inability for the user to see the detailed error message returned
+by the server (the offending character position, the human-readable
+error code) is an aggravating cause of this bug. Propagating the
+server-side `ContextMessage` up to the CLI is a separate concern, to
+be addressed in a dedicated ticket.

--- a/document-server/src/filter/filter_lexer.rs
+++ b/document-server/src/filter/filter_lexer.rs
@@ -523,8 +523,12 @@ fn condition_lexer_index(
                         append_attribute(&mut attribute, &mut expected_lexeme, &mut tokens, *index.borrow(), offset)?;
                     }
                     ConditionExpectedLexeme::FilterOperator => {
-                        // Add the filter operator and change the expected lexeme to Value
-                        append_fop(&mut fop, &mut expected_lexeme, &mut tokens, *index.borrow(), offset)?;
+                        // B0001: tolerate multiple spaces between the attribute and the operator.
+                        // Mirror the FilterOperator -> Value transition below, which already
+                        // skips spaces while no value character has been read.
+                        if !fop.is_empty() {
+                            append_fop(&mut fop, &mut expected_lexeme, &mut tokens, *index.borrow(), offset)?;
+                        }
                     }
                     ConditionExpectedLexeme::Value => {
                         if text_mode {
@@ -1069,6 +1073,27 @@ mod tests {
             Token::LogicalClose(PositionalToken::new((), pos[4])),
             //Token::LogicalClose(PositionalToken::new((), input.chars().count() + 1)),
         ];
+        assert_eq!(expected, tokens);
+    }
+
+    /// B0001 — Multiple spaces between the attribute and the comparison operator
+    /// must be tolerated, by symmetry with the spaces handled between the
+    /// operator and the value.
+    #[test]
+    pub fn lexer_simple_5_b0001_multispace_before_operator() {
+        init_logger();
+        let pos = vec![1, 2, 13, 15, 17];
+        let input = "(attribut1  > 10)";
+        let tokens = lex3(input).unwrap();
+
+        let expected: Vec<Token> = vec![
+            Token::LogicalOpen(PositionalToken::new((), pos[0])),
+            Token::Attribute(PositionalToken::new("attribut1".to_string(), pos[1])),
+            Token::Operator(PositionalToken::new(ComparisonOperator::GT, pos[2])),
+            Token::ValueInt(PositionalToken::new(10, pos[3])),
+            Token::LogicalClose(PositionalToken::new((), pos[4])),
+        ];
+
         assert_eq!(expected, tokens);
     }
 


### PR DESCRIPTION
…lter lexer

The condition lexer rejected filters such as `(val  > 100)` (two spaces before the operator) with `UnknownFilterOperator`, surfaced as HTTP 400. The space handler in the `FilterOperator` state validated an empty operator string instead of skipping the space, contrary to the neighbouring `Value` branch that already tolerates leading spaces.

Add a guard so the space is skipped while no operator character has been read, and a regression test covering the case.