### PR TITLE
feat(F0005): Date filter support with typed resolver pipeline

### DIFF
--- a/_ai/F0005-date-filter-support/F0005.md
+++ b/_ai/F0005-date-filter-support/F0005.md
@@ -1,0 +1,106 @@
+
+```yaml
+id: DATE-FILTER-SUPPORT
+flow-id: DOKA-ITEM-SEARCH
+type: feature
+status: draft
+language: Rust
+related_entities: [ITEM-SEARCH, ITEM-FILTER]
+related_tests: [IT-F0005]
+```
+
+# Goal
+Allow filter expressions on tags of type `Date`, e.g. `(birthdate == "2025-12-31")`, with the full set of ordered comparison operators. The literal uses the same double-quoted syntax as `Text`, but is parsed and emitted as a SQL `DATE`.
+
+# Gap
+`build_tag_value_filter` is a `todo!()` for `TagType::Date`, and `Date` is missing from `LEGAL_OPERATORS_BY_TAG_TYPE` — any filter on a date tag panics at SQL-build time. The lexer/parser cannot type a literal on their own: `TagDefinition`s are only loaded later, inside `compile_search_query`. A seam is needed between parsing and SQL emission to enrich the AST with the real value types.
+
+# Inputs
+A condition shaped exactly like a text condition: `(birthdate == "2025-12-31")`, `(birthdate >= "2000-01-01")`, `(birthdate != "1977-04-22")`. The literal between the double quotes is an ISO-8601 calendar date (`YYYY-MM-DD`), validated by the existing `commons_pg::sql_transaction::iso_to_naivedate` helper. No timezone, no time part.
+
+# Output
+A `WHERE` fragment that compares `tv.value_date` against a SQL `DATE` literal: `tv.value_date = DATE '2025-12-31'`, `tv.value_date >= DATE '2000-01-01'`, `tv.value_date <> DATE '1977-04-22'`.
+
+# Architecture — three independent stages
+F0005 makes filter compilation an explicit pipeline of three single-responsibility stages:
+
+| Stage          | Input                                          | Output                          | Module                              |
+|----------------|------------------------------------------------|---------------------------------|-------------------------------------|
+| Parsing        | `&str`                                         | `Box<FilterExpressionAST>` (untyped) | `filter/filter_ast.rs` (unchanged)  |
+| Type resolver  | `(FilterExpressionAST, Vec<TagDefinition>)`    | `ResolvedFilter` (typed)        | `filter/type_resolver.rs` (NEW)     |
+| SQL generation | `ResolvedFilter`                               | `CompiledSearchQuery`           | `engine/generator.rs` (modified)    |
+
+The resolver is a **transformation, not a mutation**: it consumes the untyped AST + definitions by value and produces a brand-new bundle. Carrying `definitions` inside `ResolvedFilter` makes the SQL stage's precondition visible in the type system — untyped ASTs cannot reach SQL gen without going through the resolver.
+
+# Rules
+
+1. **New AST variant.** Add `FilterValue::ValueDate(chrono::NaiveDate)` to the `FilterValue` enum. Exhaustive-match sites updated: `fmt::Display` formats as `YYYY-MM-DD`; `to_sql_literal` gets a defensive arm `format!("DATE '{}'", d)` (not reached for `Date` tags in practice; needed only for match exhaustiveness); `parse_tokens_with_index` is **unchanged** — parser still emits `ValueString` for any quoted literal.
+
+2. **Type resolver module** (`filter/type_resolver.rs`, NEW):
+   
+   ```rust
+   pub(crate) struct ResolvedFilter { pub ast: FilterExpressionAST, pub definitions: Vec<TagDefinition> }
+   pub(crate) fn collect_attribute_names(ast: &FilterExpressionAST) -> HashSet<String>;
+   pub(crate) fn resolve_filter_value_types(ast: FilterExpressionAST, definitions: Vec<TagDefinition>) -> Result<ResolvedFilter, FilterResolutionError>;
+   pub(crate) enum FilterResolutionError {
+       InvalidDateLiteral     { tag: String, value: String },
+       IncompatibleValueShape { tag: String, tag_type: TagType, got: &'static str },
+   }
+   ```
+   For each `Condition` whose attribute resolves to `TagType::Date`, the resolver validates the `ValueString` via `iso_to_naivedate` and rewrites the value to `FilterValue::ValueDate(NaiveDate)`. Other variants pass through. SQL generation contains no string-to-date conversion.
+   
+3. **`compile_search_query` orchestrates the pipeline.** Signature changes from `&FilterExpressionAST` to owned `FilterExpressionAST`. Flow: `collect_attribute_names → load definitions → verify-tags-exist → resolve_filter_value_types → extract_all_conditions → verify_filter_conditions → SQL emission`. The single caller in `search_delegate` passes the parsed AST by value.
+
+4. **Operators.** Add `TagType::Date` to `LEGAL_OPERATORS_BY_TAG_TYPE` with `EQ, NEQ, GT, GTE, LT, LTE`. `LIKE` is **not** allowed.
+
+5. **SQL emission — pure formatter.** Replace the `TagType::Date => todo!()` arm in `build_tag_value_filter`:
+   ```rust
+   TagType::Date => match &filter_condition.value {
+       FilterValue::ValueDate(d) => format!("tv.value_date {} DATE '{}'", sql_op, d),
+       other => return Err(GenerationError::TagIncompatibleType(format!(
+           "Tag : {}, expected date literal, got {:?}", filter_condition.attribute, other))),
+   }
+   ```
+   `NaiveDate::Display` emits `YYYY-MM-DD` — fixed-width, no SQL-special chars, safe to embed without further escaping.
+
+6. **Backward compatibility & persistence.** `Text`/`Int`/`Bool`/`Double` filters take the same code path: the resolver leaves their values untouched, SQL gen behaves as before. No change to persistence (`persist_compiled_query`) — the persisted artefact is the SQL string, which already carries the embedded `DATE 'YYYY-MM-DD'` literal. No `serde` derives are added.
+
+# Errors
+
+| Condition                                           | Stage that rejects         | Outcome                                  |
+|-----------------------------------------------------|----------------------------|------------------------------------------|
+| `(birthdate == "2025-13-40")` (not a real date)     | Type resolver              | 400 — `InvalidDateLiteral`               |
+| `(birthdate == 2025)` (int literal on Date tag)     | Type resolver              | 400 — `IncompatibleValueShape`           |
+| `(birthdate LIKE "2025%")`                          | `verify_filter_conditions` | 400 — operator not allowed for `Date`    |
+| `(birthdate == "2025-12-31")` on a `Text` tag       | Type resolver (no rewrite) | 200 — treated as text (`unaccent_lower`) |
+
+# Examples — wire input to final WHERE fragment
+
+| Filter input                  | Tag type | Emitted WHERE fragment               |
+|-------------------------------|----------|--------------------------------------|
+| `(birthdate == "2025-12-31")` | Date     | `tv.value_date = DATE '2025-12-31'`  |
+| `(birthdate >= "2000-01-01")` | Date     | `tv.value_date >= DATE '2000-01-01'` |
+| `(birthdate != "1977-04-22")` | Date     | `tv.value_date <> DATE '1977-04-22'` |
+| `(birthdate LIKE "2025%")`    | Date     | n/a — 400                            |
+| `(birthdate == "not-a-date")` | Date     | n/a — 400                            |
+
+# Implementation surface
+- `filter/filter_ast.rs` — new `ValueDate(NaiveDate)` variant; `Display` arm.
+- `filter/mod.rs` — `to_sql_literal` defensive arm; `mod type_resolver;`.
+- `filter/type_resolver.rs` — **new file**.
+- `engine/generator.rs` — `compile_search_query` orchestration; new entry in `LEGAL_OPERATORS_BY_TAG_TYPE`; replace `todo!()` arm.
+- `search/search_delegate.rs` — pass AST by value to `compile_search_query`.
+
+No change to lexer, normaliser, parser body, CLI client, HTTP route, or projection logic.
+
+
+
+# Coding Norms
+
+Follow the coding norms from : _ai/guides/Code standards and norms.md
+
+
+
+# Integration tests
+
+End-to-end black-box validation lives in [integration_test_date_filter.md](./integration_test_date_filter.md) (IT-F0005), implemented in `doka-api-tests/tests/F0005-date-filter-support.rs`.

--- a/_ai/F0005-date-filter-support/unit_test_date_filter.md
+++ b/_ai/F0005-date-filter-support/unit_test_date_filter.md
@@ -1,0 +1,121 @@
+
+```yaml
+id: UT-F0005
+title: Unit tests — Date filter support
+type: unit-test
+status: draft
+target_flow: DOKA-ITEM-SEARCH
+related_feature: F0005
+naming_prefix: UT-F0005
+language: rust
+```
+
+# Coverage goal
+White-box validation of the three new touch points introduced by F0005, exercised in-process via `cargo test --bin document-server`:
+
+- the new `filter/type_resolver.rs` module (`collect_attribute_names`, `resolve_filter_value_types`, `ResolvedFilter`, `FilterResolutionError`);
+- the new `TagType::Date` arm in `build_tag_value_filter` and the new entry in `LEGAL_OPERATORS_BY_TAG_TYPE`;
+- the new `FilterValue::ValueDate` variant's `Display` impl and the `to_sql_literal` defensive arm.
+
+End-to-end HTTP behaviour is covered separately by [IT-F0005](./integration_test_date_filter.md).
+
+# System under test
+Functions are called directly inside `#[cfg(test)]` modules. No HTTP layer, no DB, no `admin-server`. **Resolver tests build their input AST by direct enum construction** (`FilterExpressionAST::Condition { ... }`, `FilterExpressionAST::Logical { ... }`) — *not* via `analyse_expression`. This isolates a resolver-test failure to a resolver bug; lexer/parser behaviour is already covered by the existing tests around `analyse_expression` and `parse_tokens`. Each test also supplies a small hand-built `Vec<TagDefinition>` and asserts against the returned `ResolvedFilter` or `FilterResolutionError`.
+
+# Test cases
+
+## type_resolver (new module — 6 cases)
+
+### TC-F0005-001 — `collect_attribute_names` walks AND/OR trees
+Given: an AST built by direct construction —
+```
+Logical { AND, [
+  Condition { attribute: "birthdate", op: EQ, value: ValueString("2025-12-31") },
+  Logical { OR, [
+    Condition { attribute: "age",  op: GT, value: ValueInt(18) },
+    Condition { attribute: "city", op: EQ, value: ValueString("Paris") },
+  ]},
+]}
+```
+When: `collect_attribute_names(&ast)`.
+Then: returns the set `{"birthdate", "age", "city"}`. Proves the walk visits every `Condition` leaf inside nested `Logical` nodes — no parser involvement.
+
+### TC-F0005-002 — `resolve_filter_value_types` happy path
+Given: an AST built directly as `Condition { attribute: "birthdate", op: EQ, value: ValueString("2025-12-31") }` + `definitions = [TagDefinition { tag_names: "birthdate", tag_type: Date }]`.
+When: `resolve_filter_value_types(ast, definitions)`.
+Then: `Ok(ResolvedFilter { ast, definitions })` where the single `Condition`'s `value` is `FilterValue::ValueDate(NaiveDate::from_ymd_opt(2025, 12, 31).unwrap())`. Proves the rewrite produces a `chrono::NaiveDate`, not a string.
+
+### TC-F0005-003 — Invalid date literal is rejected
+Given: hand-built AST `Condition { attribute: "birthdate", op: EQ, value: ValueString("2025-13-40") }` + birthdate-as-Date definition.
+When: `resolve_filter_value_types(ast, definitions)`.
+Then: `Err(FilterResolutionError::InvalidDateLiteral { tag: "birthdate", value: "2025-13-40" })`. Repeat with `ValueString("not-a-date")` — same error.
+
+### TC-F0005-004 — Wrong value shape on a Date tag
+Given: hand-built AST `Condition { attribute: "birthdate", op: EQ, value: FilterValue::ValueInt(2025) }` + birthdate-as-Date definition. (This shape cannot be produced by the parser; the resolver must still reject it defensively.)
+When: `resolve_filter_value_types(...)`.
+Then: `Err(FilterResolutionError::IncompatibleValueShape { tag: "birthdate", tag_type: Date, got: "ValueInt" })`.
+
+### TC-F0005-005 — Non-Date tags pass through unchanged
+Given: hand-built AST —
+```
+Logical { AND, [
+  Condition { attribute: "name", op: EQ, value: ValueString("alice") },
+  Condition { attribute: "age",  op: GT, value: ValueInt(18) },
+]}
+```
++ definitions `[name: Text, age: Int]`.
+When: `resolve_filter_value_types(...)`.
+Then: `Ok(resolved)` where each `Condition.value` is bit-for-bit identical to the input (`ValueString("alice")`, `ValueInt(18)`). Proves the resolver is a no-op outside the `Date` case.
+
+### TC-F0005-006 — `ResolvedFilter.definitions` preserves the input
+Given: a `definitions` vec of length 3 in a specific order + any trivial hand-built AST referencing one of them.
+When: `resolve_filter_value_types(...)`.
+Then: `resolved.definitions` equals the input vec by element and order. Proves the bundle moves ownership without reordering or dropping entries — SQL gen relies on linear lookups by name.
+
+## engine/generator (4 cases added to the existing `#[cfg(test)]` module)
+
+### TC-F0005-007 — `build_tag_value_filter` emits `DATE 'YYYY-MM-DD'` for EQ
+Given: `FilterCondition { attribute: "birthdate", operator: EQ, value: ValueDate(NaiveDate::from_ymd_opt(2025,12,31).unwrap()) }` + `tag_type = TagType::Date`.
+When: `build_tag_value_filter(&fc, &tag_type)`.
+Then: `Ok("tv.value_date = DATE '2025-12-31'")`. Note the `DATE '…'` prefix — a bare `'2025-12-31'` would be wrong.
+
+### TC-F0005-008 — All ordered operators emit the right symbol
+Table-driven over `{NEQ → <>, GT → >, GTE → >=, LT → <, LTE → <=}` on the same date literal. Proves the operator switch reused from text/int paths applies to dates.
+
+### TC-F0005-009 — Defensive arm rejects non-`ValueDate` values
+Given: `FilterCondition { ..., value: ValueString("2025-12-31") }` + `tag_type = TagType::Date` (only reachable if the resolver was bypassed — defensive check).
+When: `build_tag_value_filter(&fc, &Date)`.
+Then: `Err(GenerationError::TagIncompatibleType(_))` mentioning the attribute name. Proves the SQL stage refuses to silently fall back to text behaviour.
+
+### TC-F0005-010 — `LIKE` is rejected on a Date tag at the operator-check stage
+Given: `filter_conditions` containing `(birthdate LIKE "x")` + `definitions = [birthdate: Date]`.
+When: `verify_filter_conditions(&filter_conditions, &definitions)`.
+Then: `Err(GenerationError::TagIncompatibleType(_))`. Proves `LEGAL_OPERATORS_BY_TAG_TYPE[Date]` excludes `LIKE` (the entry must include exactly `EQ, NEQ, GT, GTE, LT, LTE`).
+
+## filter/filter_ast + filter/mod (2 cases)
+
+### TC-F0005-011 — `Display` for `ValueDate` emits ISO `YYYY-MM-DD`
+Given: `FilterValue::ValueDate(NaiveDate::from_ymd_opt(2025,12,31).unwrap())`.
+When: `format!("{}", v)`.
+Then: `"2025-12-31"`. Proves alignment with the SQL emission format and prevents accidental locale-dependent formatting.
+
+### TC-F0005-012 — `to_sql_literal` defensive arm for `ValueDate`
+Given: `FilterValue::ValueDate(NaiveDate::from_ymd_opt(2025,12,31).unwrap())` + any non-LIKE operator.
+When: `to_sql_literal(&v, &op)`.
+Then: `"DATE '2025-12-31'"`. This arm is unreachable in the F0005 pipeline (the `Date` branch of `build_tag_value_filter` emits SQL directly), but the match must be exhaustive — the test guards against the arm silently emitting `'2025-12-31'` without the `DATE` prefix if the surrounding code ever delegates to it.
+
+# Regression coverage
+All existing tests across `filter/filter_lexer.rs`, `filter/filter_normalizer.rs`, `filter/filter_ast.rs`, `filter/mod.rs`, and `engine/generator.rs` must continue to pass with **no test-body edits**. The only compilation effect of F0005 on existing code is the two new exhaustive-match arms (`Display`, `to_sql_literal`); once they are added, every `Text`/`Int`/`Bool`/`Double` filter test runs untouched. A CI failure on any pre-existing test name indicates an unintended regression in F0005, not a missing update.
+
+# Test file
+The new cases live in the `#[cfg(test)]` module of their owning production file:
+
+- TC-F0005-001…006 — `document-server/src/filter/type_resolver.rs` (new file, `mod tests`).
+- TC-F0005-007…010 — appended to the existing `#[cfg(test)] mod tests` in `document-server/src/engine/generator.rs`.
+- TC-F0005-011 — appended to `#[cfg(test)] mod tests` in `document-server/src/filter/filter_ast.rs`.
+- TC-F0005-012 — appended to `#[cfg(test)] mod tests` in `document-server/src/filter/mod.rs`.
+
+Run with `cargo test --color=always --bin document-server F0005` (substring match catches all new cases by their `TC-F0005-…` naming).
+
+# Coding norms
+Follow the coding norms from : _ai/guides/Code standards and norms.md

--- a/dkdto/src/web_types.rs
+++ b/dkdto/src/web_types.rs
@@ -413,7 +413,7 @@ const TAG_TYPE_DATE: &str = "date";
 const TAG_TYPE_DATETIME: &str = "datetime";
 const TAG_TYPE_LINK: &str = "link";
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum TagType {
     Text,
     Bool,

--- a/document-server/src/engine/generator.rs
+++ b/document-server/src/engine/generator.rs
@@ -1,5 +1,6 @@
 use crate::filter::filter_ast::{ComparisonOperator, FilterCondition, FilterExpressionAST, FilterValue};
 use crate::filter::to_sql_literal;
+use crate::filter::type_resolver::{FilterResolutionError, collect_attribute_names, resolve_filter_value_types};
 use axum::async_trait;
 use commons_error::tr_fwd;
 use commons_error::*;
@@ -40,6 +41,17 @@ static LEGAL_OPERATORS_BY_TAG_TYPE: Lazy<HashMap<TagType, Vec<ComparisonOperator
         ],
     );
     map.insert(TagType::Text, vec![ComparisonOperator::EQ, ComparisonOperator::NEQ, ComparisonOperator::LIKE]);
+    map.insert(
+        TagType::Date,
+        vec![
+            ComparisonOperator::EQ,
+            ComparisonOperator::NEQ,
+            ComparisonOperator::GT,
+            ComparisonOperator::GTE,
+            ComparisonOperator::LT,
+            ComparisonOperator::LTE,
+        ],
+    );
     map
 });
 
@@ -162,6 +174,8 @@ pub(crate) enum GenerationError {
     TagTypeUnknown(String),
     TagSearchError(String),
     TagIncompatibleType(String),
+    InvalidDateLiteral { tag: String, value: String },
+    IncompatibleValueShape { tag: String, tag_type: TagType, got: &'static str },
 }
 
 impl fmt::Display for GenerationError {
@@ -272,9 +286,15 @@ fn build_tag_value_filter(filter_condition: &FilterCondition, tag_type: &TagType
         TagType::Double => {
             format!("tv.value_double {0} {1}", &sql_op, &filter_condition.value)
         }
-        TagType::Date => {
-            todo!();
-        }
+        TagType::Date => match &filter_condition.value {
+            FilterValue::ValueDate(d) => format!("tv.value_date {} DATE '{}'", sql_op, d),
+            other => {
+                return Err(GenerationError::TagIncompatibleType(format!(
+                    "Tag : {}, expected date literal, got {:?}",
+                    filter_condition.attribute, other
+                )));
+            }
+        },
         TagType::DateTime => {
             todo!();
         }
@@ -319,7 +339,7 @@ fn verify_filter_conditions(
 }
 
 fn build_order_column(
-    order_tags: &Vec<String>,
+    order_tags: &[String],
     map_of_tags_with_occurrence: &HashMap<String, Vec<String>>,
 ) -> Vec<String> {
     order_tags
@@ -366,27 +386,24 @@ fn build_tag_column_with_alias(
         .collect()
 }
 
-/// 🔑 Generate the SQL query from the filter AST
-///    
-///     REF_TAG : DOKA_SEARCH_SQL
-pub(crate) async fn compile_search_query<T: TagDefinitionInterface>(
-    filter_expression_ast: &FilterExpressionAST,
+/// Resolve phase of the search-query pipeline.
+///
+/// Steps: `collect_attribute_names` → load `TagDefinition`s for filter +
+/// order tags → verify every referenced tag exists → `resolve_filter_value_types`
+/// (rewrites `ValueString` → `ValueDate` for `Date` tags).
+///
+/// Returns the typed AST and the owned definitions vector. Callers feed
+/// the pair into `generate_sql_from_resolved`.
+///
+/// REF_TAG : DOKA_SEARCH_SQL
+pub(crate) async fn resolve_filter<T: TagDefinitionInterface>(
+    filter_expression_ast: FilterExpressionAST,
     tag_definition_builder: &T,
-    select_tags: &[String],
-    order_tags: &Vec<String>,
-    _generation_mode: SearchSqlGenerationMode,
+    order_tags: &[String],
     customer_code: &str,
-) -> Result<CompiledSearchQuery, GenerationError> {
-    // Get all the final nodes (leaves), for instance, == (lastname, "a%" )
-    let filter_conditions = extract_all_conditions(&filter_expression_ast).map_err(tr_fwd!())?;
-
-    dbg!(&filter_conditions);
-
-    // Extract all the tags name from each leaves
-    let mut tags: HashSet<_> =
-        filter_conditions.iter().map(|(_, (_, filter_condition))| filter_condition.attribute.clone()).collect();
-
-    tags.extend(order_tags.iter().map(|s| s.to_string()));
+) -> Result<(FilterExpressionAST, Vec<TagDefinition>), GenerationError> {
+    let mut tags: HashSet<String> = collect_attribute_names(&filter_expression_ast);
+    tags.extend(order_tags.iter().cloned());
 
     dbg!(&tags);
 
@@ -417,6 +434,39 @@ pub(crate) async fn compile_search_query<T: TagDefinitionInterface>(
             return Err(GenerationError::TagUnknown(tag.clone()));
         }
     }
+
+    // F0005: type-resolve the AST (rewrites ValueString → ValueDate for Date tags)
+    // before any further analysis. From here on, the AST is typed.
+    let resolved = resolve_filter_value_types(filter_expression_ast, definitions).map_err(|e| match e {
+        FilterResolutionError::InvalidDateLiteral { tag, value } => GenerationError::InvalidDateLiteral { tag, value },
+        FilterResolutionError::IncompatibleValueShape { tag, tag_type, got } => {
+            GenerationError::IncompatibleValueShape { tag, tag_type, got }
+        }
+    })?;
+
+    Ok((resolved.ast, resolved.definitions))
+}
+
+/// 🔑 SQL-generation phase of the search-query pipeline.
+///
+/// Consumes the typed AST and definitions produced by `resolve_filter`,
+/// builds the per-condition `LEFT OUTER JOIN`s (plus synthetic joins for
+/// order-only tags), the boolean filter, the ORDER BY columns, and
+/// assembles the final `SELECT` together with per-condition stat queries.
+///
+///     REF_TAG : DOKA_SEARCH_SQL
+pub(crate) async fn generate_sql_from_resolved(
+    filter_expression_ast: FilterExpressionAST,
+    definitions: Vec<TagDefinition>,
+    select_tags: &[String],
+    order_tags: &[String],
+    _generation_mode: SearchSqlGenerationMode,
+    customer_code: &str,
+) -> Result<CompiledSearchQuery, GenerationError> {
+    // Extract all conditions from the resolved (typed) AST.
+    let filter_conditions = extract_all_conditions(&filter_expression_ast).map_err(tr_fwd!())?;
+
+    dbg!(&filter_conditions);
 
     // Verify if the filter conditions are compatible with the tag type
     if let Err(e) = verify_filter_conditions(&filter_conditions, &definitions) {
@@ -465,11 +515,7 @@ pub(crate) async fn compile_search_query<T: TagDefinitionInterface>(
         if map_of_tags_with_occurrence.contains_key(order_tag) {
             continue;
         }
-        let tag_type = definitions
-            .iter()
-            .find(|def| &def.tag_names == order_tag)
-            .map(|def| &def.tag_type)
-            .unwrap();
+        let tag_type = definitions.iter().find(|def| &def.tag_names == order_tag).map(|def| &def.tag_type).unwrap();
 
         let synthetic_join = QUERY_FILTER_TEMPLATE
             .replace("{{value_column_name}}", tag_type.value_column_name())
@@ -542,23 +588,18 @@ pub(crate) async fn compile_search_query<T: TagDefinitionInterface>(
 }
 
 pub(crate) async fn generate_search_sql<T: TagDefinitionInterface>(
-    filter_expression_ast: &FilterExpressionAST,
+    filter_expression_ast: FilterExpressionAST,
     tag_definition_builder: &T,
     select_tags: &[String],
     order_tags: &Vec<String>,
     generation_mode: SearchSqlGenerationMode,
     customer_code: &str,
 ) -> Result<String, GenerationError> {
-    compile_search_query(
-        filter_expression_ast,
-        tag_definition_builder,
-        select_tags,
-        order_tags,
-        generation_mode,
-        customer_code,
-    )
-    .await
-    .map(|compiled| compiled.main_sql)
+    let (resolved_ast, definitions) =
+        resolve_filter(filter_expression_ast, tag_definition_builder, order_tags, customer_code).await?;
+    generate_sql_from_resolved(resolved_ast, definitions, select_tags, order_tags, generation_mode, customer_code)
+        .await
+        .map(|compiled| compiled.main_sql)
 }
 
 /// tag_value_filter and tag_super_filter are side by side to avoid a blank line
@@ -632,8 +673,9 @@ mod tests {
     // cargo test --color=always --bin document-server engine  [ -- --show-output]
 
     use crate::engine::generator::{
-        build_query_filter, build_tag_value_filter, compile_search_query, extract_all_conditions, generate_search_sql,
-        verify_filter_conditions, GenerationError, SearchSqlGenerationMode, TagDefinition, TagDefinitionInterface,
+        GenerationError, SearchSqlGenerationMode, TagDefinition, TagDefinitionInterface, build_query_filter,
+        build_tag_value_filter, extract_all_conditions, generate_search_sql, generate_sql_from_resolved,
+        resolve_filter, verify_filter_conditions,
     };
     use crate::filter::analyse_expression;
     use crate::filter::filter_ast::{ComparisonOperator, FilterCondition, FilterValue};
@@ -654,8 +696,8 @@ mod tests {
     pub(crate) fn init_logger() {
         INIT_LOGGER.call_once(|| {
             if let Err(e) = log4rs::init_file(
-                // "/home/denis/Projects/wks-doka-one/doka.one/document-server/log4rs.yaml",
-                r#"C:\Users\gcres\Projects\wks-doka-one\doka.one\document-server\log4rs.yaml"#,
+                "/home/denis/Projects/wks-doka-one/doka.one/document-server/log4rs.yaml",
+                // r#"C:\Users\gcres\Projects\wks-doka-one\doka.one\document-server\log4rs.yaml"#,
                 Default::default(),
             ) {
                 eprintln!("logger init skipped: {:?}", e);
@@ -764,7 +806,7 @@ mod tests {
         let tag_definition_builder = TagDefinitionBuilderMock {};
 
         let query = generate_search_sql(
-            &filter_expression_ast,
+            *filter_expression_ast,
             &tag_definition_builder,
             &vec!["country".to_string(), "science".to_string(), "is_open".to_string()],
             &vec!["country".to_string(), "science".to_string(), "is_open".to_string()],
@@ -805,7 +847,7 @@ mod tests {
         let filter_expression_ast = analyse_expression(input).unwrap();
         let tag_definition_builder = TagDefinitionBuilderMock2 {};
         let query = generate_search_sql(
-            &filter_expression_ast,
+            *filter_expression_ast,
             &tag_definition_builder,
             &vec!["".to_string()],
             &vec!["lastname".to_string(), "postal_code".to_string()],
@@ -827,9 +869,18 @@ mod tests {
         let filter_expression_ast = analyse_expression(input).unwrap();
         let tag_definition_builder = TagDefinitionBuilderMock2 {};
 
-        let compiled = compile_search_query(
-            &filter_expression_ast,
+        let (resolved_ast, definitions) = resolve_filter(
+            *filter_expression_ast,
             &tag_definition_builder,
+            &vec!["lastname".to_string(), "postal_code".to_string()],
+            "123456",
+        )
+        .await
+        .unwrap();
+
+        let compiled = generate_sql_from_resolved(
+            resolved_ast,
+            definitions,
             &vec!["lastname".to_string()],
             &vec!["lastname".to_string(), "postal_code".to_string()],
             SearchSqlGenerationMode::Persisted,
@@ -852,9 +903,12 @@ mod tests {
         let filter_expression_ast = analyse_expression(r#"(country == "FR")"#).unwrap();
         let tag_definition_builder = TagDefinitionBuilderMock {};
 
-        let compiled = compile_search_query(
-            &filter_expression_ast,
-            &tag_definition_builder,
+        let (resolved_ast, definitions) =
+            resolve_filter(*filter_expression_ast, &tag_definition_builder, &vec![], "123456").await.unwrap();
+
+        let compiled = generate_sql_from_resolved(
+            resolved_ast,
+            definitions,
             &vec!["country".to_string()],
             &vec![],
             SearchSqlGenerationMode::Persisted,
@@ -960,7 +1014,7 @@ mod tests {
         let boolean_filter = build_query_filter(tree1.as_ref(), &all_conditions).unwrap();
         log_debug!("boolean filter: {}", &boolean_filter);
 
-        const EXPECTED : &str = "(( ot_country_0.value is not null  AND  ot_science_0.value is not null ) OR ( ot_is_open_0.value is not null  OR ( ot_country_1.value is not null  AND  ot_science_1.value is not null )))";
+        const EXPECTED: &str = "(( ot_country_0.value is not null  AND  ot_science_0.value is not null ) OR ( ot_is_open_0.value is not null  OR ( ot_country_1.value is not null  AND  ot_science_1.value is not null )))";
         assert_eq!(EXPECTED, &boolean_filter);
     }
 
@@ -1018,5 +1072,92 @@ mod tests {
         let sql = build_tag_value_filter(&filter_condition, &TagType::Bool).unwrap();
 
         assert_eq!("tv.value_boolean <> FALSE", sql);
+    }
+
+    // === UT-F0005 : Date filter support ===
+
+    // TC-F0005-007 — `build_tag_value_filter` emits `DATE 'YYYY-MM-DD'` for EQ
+    #[test]
+    pub fn ut_f0005_007_build_tag_value_filter_date_eq() {
+        use chrono::NaiveDate;
+        let fc = FilterCondition {
+            key: "1".to_string(),
+            attribute: "birthdate".to_string(),
+            operator: ComparisonOperator::EQ,
+            value: FilterValue::ValueDate(NaiveDate::from_ymd_opt(2025, 12, 31).unwrap()),
+        };
+
+        let sql = build_tag_value_filter(&fc, &TagType::Date).unwrap();
+
+        assert_eq!("tv.value_date = DATE '2025-12-31'", sql);
+    }
+
+    // TC-F0005-008 — All ordered operators emit the right symbol
+    #[test]
+    pub fn ut_f0005_008_build_tag_value_filter_date_all_operators() {
+        use chrono::NaiveDate;
+        let date = NaiveDate::from_ymd_opt(2025, 12, 31).unwrap();
+        let cases = [
+            (ComparisonOperator::NEQ, "<>"),
+            (ComparisonOperator::GT, ">"),
+            (ComparisonOperator::GTE, ">="),
+            (ComparisonOperator::LT, "<"),
+            (ComparisonOperator::LTE, "<="),
+        ];
+
+        for (op, sym) in cases {
+            let fc = FilterCondition {
+                key: "1".to_string(),
+                attribute: "birthdate".to_string(),
+                operator: op.clone(),
+                value: FilterValue::ValueDate(date),
+            };
+            let sql = build_tag_value_filter(&fc, &TagType::Date).unwrap();
+            assert_eq!(format!("tv.value_date {} DATE '2025-12-31'", sym), sql, "op={:?}", op);
+        }
+    }
+
+    // TC-F0005-009 — Defensive arm rejects non-`ValueDate` values
+    #[test]
+    pub fn ut_f0005_009_build_tag_value_filter_date_defensive() {
+        let fc = FilterCondition {
+            key: "1".to_string(),
+            attribute: "birthdate".to_string(),
+            operator: ComparisonOperator::EQ,
+            value: FilterValue::ValueString("2025-12-31".to_string()),
+        };
+
+        match build_tag_value_filter(&fc, &TagType::Date) {
+            Err(GenerationError::TagIncompatibleType(msg)) => {
+                assert!(msg.contains("birthdate"), "expected attribute name in error, got: {}", msg);
+            }
+            other => panic!("Expected TagIncompatibleType, got {:?}", other),
+        }
+    }
+
+    // TC-F0005-010 — `LIKE` is rejected on a Date tag at the operator-check stage
+    #[test]
+    pub fn ut_f0005_010_verify_filter_conditions_rejects_like_on_date() {
+        use crate::filter::filter_lexer::PatternPart;
+        let definitions = vec![TagDefinition { tag_names: "birthdate".to_string(), tag_type: TagType::Date }];
+
+        let mut filter_conditions = HashMap::new();
+        filter_conditions.insert(
+            "1".to_string(),
+            (
+                0,
+                FilterCondition {
+                    key: "1".to_string(),
+                    attribute: "birthdate".to_string(),
+                    operator: ComparisonOperator::LIKE,
+                    value: FilterValue::ValuePattern(vec![PatternPart::Literal("x".to_string())]),
+                },
+            ),
+        );
+
+        match verify_filter_conditions(&filter_conditions, &definitions) {
+            Err(GenerationError::TagIncompatibleType(_)) => {}
+            other => panic!("Expected TagIncompatibleType, got {:?}", other),
+        }
     }
 }

--- a/document-server/src/filter/filter_ast.rs
+++ b/document-server/src/filter/filter_ast.rs
@@ -5,6 +5,7 @@ use crate::filter::filter_lexer::FilterErrorCode::{
     AttributeExpected, ClosingExpected, LogicalOperatorExpected, OpeningExpected, OperatorExpected, ValueExpected,
 };
 use crate::filter::filter_lexer::{FilterError, LogicalOperator, PatternPart, Token};
+use chrono::NaiveDate;
 use commons_error::*;
 use log::*;
 use rs_uuid::uuid8;
@@ -35,6 +36,7 @@ pub(crate) enum FilterValue {
     ValueString(String),
     ValuePattern(Vec<PatternPart>),
     ValueBool(bool),
+    ValueDate(NaiveDate),
 }
 
 impl fmt::Display for FilterValue {
@@ -57,6 +59,9 @@ impl fmt::Display for FilterValue {
             }
             FilterValue::ValueBool(b) => {
                 write!(f, "{}", if *b { "TRUE" } else { "FALSE" })
+            }
+            FilterValue::ValueDate(d) => {
+                write!(f, "{}", d)
             }
         }
     }
@@ -892,6 +897,16 @@ mod tests {
                 }
             },
         }
+    }
+
+    // === UT-F0005 : Date filter — Display for ValueDate ===
+
+    #[test]
+    pub fn ut_f0005_011_display_value_date() {
+        use crate::filter::filter_ast::FilterValue;
+        use chrono::NaiveDate;
+        let v = FilterValue::ValueDate(NaiveDate::from_ymd_opt(2025, 12, 31).unwrap());
+        assert_eq!("2025-12-31", format!("{}", v));
     }
 
     #[test]

--- a/document-server/src/filter/mod.rs
+++ b/document-server/src/filter/mod.rs
@@ -8,6 +8,7 @@ use log::error;
 pub(crate) mod filter_ast;
 pub(crate) mod filter_lexer;
 pub(crate) mod filter_normalizer;
+pub(crate) mod type_resolver;
 
 pub(crate) fn analyse_expression(expression: &str) -> Result<Box<FilterExpressionAST>, FilterError> {
     parser_log!("Analysing the expression : {:?}", expression; 5);
@@ -114,6 +115,7 @@ pub(crate) fn to_sql_literal(value: &FilterValue, operator: &ComparisonOperator)
         FilterValue::ValueString(s) => format!("'{}'", s.replace('\'', "''")),
         FilterValue::ValueInt(i) => i.to_string(),
         FilterValue::ValueBool(b) => (if *b { "TRUE" } else { "FALSE" }).to_string(),
+        FilterValue::ValueDate(d) => format!("DATE '{}'", d),
         FilterValue::ValuePattern(parts) => {
             // Defensive: the parser only emits `ValuePattern` paired with `LIKE`.
             let mut joined = String::new();
@@ -492,6 +494,17 @@ mod tests {
             r#"(name == "d'arc") AND (code LIKE "50#%")"#,
             r"((name = 'd''arc') AND (code LIKE '50\%' ESCAPE '\'))",
         );
+    }
+
+    // === UT-F0005 : Date filter — `to_sql_literal` defensive arm ===
+
+    #[test]
+    pub fn ut_f0005_012_to_sql_literal_value_date() {
+        use crate::filter::filter_ast::{ComparisonOperator, FilterValue};
+        use chrono::NaiveDate;
+        let v = FilterValue::ValueDate(NaiveDate::from_ymd_opt(2025, 12, 31).unwrap());
+        let s = super::to_sql_literal(&v, &ComparisonOperator::EQ);
+        assert_eq!("DATE '2025-12-31'", s);
     }
 
     #[test]

--- a/document-server/src/filter/type_resolver.rs
+++ b/document-server/src/filter/type_resolver.rs
@@ -1,0 +1,295 @@
+use std::collections::HashSet;
+
+use commons_pg::sql_transaction::iso_to_naivedate;
+use dkdto::web_types::TagType;
+
+use crate::engine::generator::TagDefinition;
+use crate::filter::filter_ast::{FilterCondition, FilterExpressionAST, FilterValue};
+
+/// F0005 — bundle of a typed (resolved) filter AST and the tag definitions
+/// it was resolved against. Carrying `definitions` makes the SQL stage's
+/// precondition visible in the type system: untyped ASTs cannot reach SQL
+/// generation without going through the resolver.
+pub(crate) struct ResolvedFilter {
+    pub ast: FilterExpressionAST,
+    pub definitions: Vec<TagDefinition>,
+}
+
+/// F0005 — errors produced by the type resolver stage.
+#[derive(Debug)]
+pub(crate) enum FilterResolutionError {
+    InvalidDateLiteral { tag: String, value: String },
+    IncompatibleValueShape { tag: String, tag_type: TagType, got: &'static str },
+}
+
+/// Walk an AST and collect every attribute name referenced by any
+/// `Condition` leaf — needed to know which `TagDefinition`s to load
+/// before SQL emission.
+pub(crate) fn collect_attribute_names(ast: &FilterExpressionAST) -> HashSet<String> {
+    let mut out = HashSet::new();
+    walk(ast, &mut out);
+    out
+}
+
+fn walk(ast: &FilterExpressionAST, out: &mut HashSet<String>) {
+    match ast {
+        FilterExpressionAST::Condition(fc) => {
+            out.insert(fc.attribute.clone());
+        }
+        FilterExpressionAST::Logical { leaves, .. } => {
+            for l in leaves {
+                walk(l, out);
+            }
+        }
+    }
+}
+
+/// Rewrite every `Condition` whose attribute resolves to `TagType::Date`:
+/// parse its `ValueString` via `iso_to_naivedate` and replace it with a
+/// `FilterValue::ValueDate(NaiveDate)`. Other variants pass through.
+pub(crate) fn resolve_filter_value_types(
+    ast: FilterExpressionAST,
+    definitions: Vec<TagDefinition>,
+) -> Result<ResolvedFilter, FilterResolutionError> {
+    let rewritten = rewrite(ast, &definitions)?;
+    Ok(ResolvedFilter { ast: rewritten, definitions })
+}
+
+fn rewrite(
+    ast: FilterExpressionAST,
+    definitions: &[TagDefinition],
+) -> Result<FilterExpressionAST, FilterResolutionError> {
+    match ast {
+        FilterExpressionAST::Condition(fc) => {
+            let rewritten = rewrite_condition(fc, definitions)?;
+            Ok(FilterExpressionAST::Condition(rewritten))
+        }
+        FilterExpressionAST::Logical { operator, leaves } => {
+            let mut new_leaves = Vec::with_capacity(leaves.len());
+            for leaf in leaves {
+                let r = rewrite(*leaf, definitions)?;
+                new_leaves.push(Box::new(r));
+            }
+            Ok(FilterExpressionAST::Logical { operator, leaves: new_leaves })
+        }
+    }
+}
+
+fn rewrite_condition(
+    fc: FilterCondition,
+    definitions: &[TagDefinition],
+) -> Result<FilterCondition, FilterResolutionError> {
+    let definition = definitions.iter().find(|d| d.tag_names == fc.attribute);
+
+    let Some(def) = definition else {
+        // The tag is unknown here — let the downstream "verify-tags-exist"
+        // stage produce the canonical TagUnknown error. Pass through unchanged.
+        return Ok(fc);
+    };
+
+    if def.tag_type != TagType::Date {
+        return Ok(fc);
+    }
+
+    match &fc.value {
+        FilterValue::ValueString(s) => {
+            let parsed = iso_to_naivedate(s).map_err(|_| FilterResolutionError::InvalidDateLiteral {
+                tag: fc.attribute.clone(),
+                value: s.clone(),
+            })?;
+            Ok(FilterCondition { value: FilterValue::ValueDate(parsed), ..fc })
+        }
+        other => {
+            let got = filter_value_kind(other);
+            Err(FilterResolutionError::IncompatibleValueShape {
+                tag: fc.attribute.clone(),
+                tag_type: def.tag_type,
+                got,
+            })
+        }
+    }
+}
+
+fn filter_value_kind(v: &FilterValue) -> &'static str {
+    match v {
+        FilterValue::ValueInt(_) => "ValueInt",
+        FilterValue::ValueString(_) => "ValueString",
+        FilterValue::ValuePattern(_) => "ValuePattern",
+        FilterValue::ValueBool(_) => "ValueBool",
+        FilterValue::ValueDate(_) => "ValueDate",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    // cargo test --color=always --bin document-server filter::type_resolver  [ -- --show-output]
+
+    use std::collections::HashSet;
+
+    use chrono::NaiveDate;
+    use dkdto::web_types::TagType;
+    use rs_uuid::uuid8;
+
+    use crate::engine::generator::TagDefinition;
+    use crate::filter::filter_ast::{ComparisonOperator, FilterCondition, FilterExpressionAST, FilterValue};
+    use crate::filter::filter_lexer::LogicalOperator;
+    use crate::filter::type_resolver::{
+        FilterResolutionError, collect_attribute_names, resolve_filter_value_types,
+    };
+
+    fn cond(attribute: &str, operator: ComparisonOperator, value: FilterValue) -> Box<FilterExpressionAST> {
+        Box::new(FilterExpressionAST::Condition(FilterCondition {
+            key: uuid8(),
+            attribute: attribute.to_string(),
+            operator,
+            value,
+        }))
+    }
+
+    // TC-F0005-001 — `collect_attribute_names` walks AND/OR trees
+    #[test]
+    fn ut_f0005_001_collect_attribute_names_walks_tree() {
+        let ast = FilterExpressionAST::Logical {
+            operator: LogicalOperator::AND,
+            leaves: vec![
+                cond("birthdate", ComparisonOperator::EQ, FilterValue::ValueString("2025-12-31".to_string())),
+                Box::new(FilterExpressionAST::Logical {
+                    operator: LogicalOperator::OR,
+                    leaves: vec![
+                        cond("age", ComparisonOperator::GT, FilterValue::ValueInt(18)),
+                        cond("city", ComparisonOperator::EQ, FilterValue::ValueString("Paris".to_string())),
+                    ],
+                }),
+            ],
+        };
+
+        let got = collect_attribute_names(&ast);
+        let expected: HashSet<String> =
+            ["birthdate".to_string(), "age".to_string(), "city".to_string()].into_iter().collect();
+        assert_eq!(expected, got);
+    }
+
+    // TC-F0005-002 — `resolve_filter_value_types` happy path
+    #[test]
+    fn ut_f0005_002_resolve_happy_path_rewrites_to_naivedate() {
+        let ast = *cond(
+            "birthdate",
+            ComparisonOperator::EQ,
+            FilterValue::ValueString("2025-12-31".to_string()),
+        );
+
+        let definitions =
+            vec![TagDefinition { tag_names: "birthdate".to_string(), tag_type: TagType::Date }];
+
+        let resolved = resolve_filter_value_types(ast, definitions).expect("must resolve");
+
+        match &resolved.ast {
+            FilterExpressionAST::Condition(fc) => match &fc.value {
+                FilterValue::ValueDate(d) => {
+                    assert_eq!(NaiveDate::from_ymd_opt(2025, 12, 31).unwrap(), *d);
+                }
+                other => panic!("Expected ValueDate, got {:?}", other),
+            },
+            other => panic!("Expected Condition, got {:?}", other),
+        }
+    }
+
+    // TC-F0005-003 — Invalid date literal is rejected
+    #[test]
+    fn ut_f0005_003_invalid_date_literal_rejected() {
+        for bad in ["2025-13-40", "not-a-date"] {
+            let ast = *cond(
+                "birthdate",
+                ComparisonOperator::EQ,
+                FilterValue::ValueString(bad.to_string()),
+            );
+            let definitions =
+                vec![TagDefinition { tag_names: "birthdate".to_string(), tag_type: TagType::Date }];
+
+            match resolve_filter_value_types(ast, definitions) {
+                Err(FilterResolutionError::InvalidDateLiteral { tag, value }) => {
+                    assert_eq!("birthdate", tag);
+                    assert_eq!(bad, value);
+                }
+                other => panic!("Expected InvalidDateLiteral for `{}`, got {:?}", bad, other.err()),
+            }
+        }
+    }
+
+    // TC-F0005-004 — Wrong value shape on a Date tag
+    #[test]
+    fn ut_f0005_004_wrong_value_shape_on_date() {
+        let ast = *cond("birthdate", ComparisonOperator::EQ, FilterValue::ValueInt(2025));
+        let definitions =
+            vec![TagDefinition { tag_names: "birthdate".to_string(), tag_type: TagType::Date }];
+
+        match resolve_filter_value_types(ast, definitions) {
+            Err(FilterResolutionError::IncompatibleValueShape { tag, tag_type, got }) => {
+                assert_eq!("birthdate", tag);
+                assert_eq!(TagType::Date, tag_type);
+                assert_eq!("ValueInt", got);
+            }
+            other => panic!("Expected IncompatibleValueShape, got {:?}", other.err()),
+        }
+    }
+
+    // TC-F0005-005 — Non-Date tags pass through unchanged
+    #[test]
+    fn ut_f0005_005_non_date_tags_pass_through() {
+        let ast = FilterExpressionAST::Logical {
+            operator: LogicalOperator::AND,
+            leaves: vec![
+                cond("name", ComparisonOperator::EQ, FilterValue::ValueString("alice".to_string())),
+                cond("age", ComparisonOperator::GT, FilterValue::ValueInt(18)),
+            ],
+        };
+        let definitions = vec![
+            TagDefinition { tag_names: "name".to_string(), tag_type: TagType::Text },
+            TagDefinition { tag_names: "age".to_string(), tag_type: TagType::Int },
+        ];
+
+        let resolved = resolve_filter_value_types(ast, definitions).expect("must resolve");
+
+        match resolved.ast {
+            FilterExpressionAST::Logical { leaves, .. } => {
+                assert_eq!(2, leaves.len());
+                match &*leaves[0] {
+                    FilterExpressionAST::Condition(fc) => match &fc.value {
+                        FilterValue::ValueString(s) => assert_eq!("alice", s),
+                        other => panic!("expected ValueString, got {:?}", other),
+                    },
+                    other => panic!("expected Condition, got {:?}", other),
+                }
+                match &*leaves[1] {
+                    FilterExpressionAST::Condition(fc) => match &fc.value {
+                        FilterValue::ValueInt(i) => assert_eq!(18, *i),
+                        other => panic!("expected ValueInt, got {:?}", other),
+                    },
+                    other => panic!("expected Condition, got {:?}", other),
+                }
+            }
+            other => panic!("Expected Logical, got {:?}", other),
+        }
+    }
+
+    // TC-F0005-006 — `ResolvedFilter.definitions` preserves the input
+    #[test]
+    fn ut_f0005_006_definitions_preserved_in_order() {
+        let definitions = vec![
+            TagDefinition { tag_names: "name".to_string(), tag_type: TagType::Text },
+            TagDefinition { tag_names: "age".to_string(), tag_type: TagType::Int },
+            TagDefinition { tag_names: "birthdate".to_string(), tag_type: TagType::Date },
+        ];
+
+        let ast = *cond("name", ComparisonOperator::EQ, FilterValue::ValueString("bob".to_string()));
+
+        let resolved = resolve_filter_value_types(ast, definitions).expect("must resolve");
+
+        let names: Vec<&str> = resolved.definitions.iter().map(|d| d.tag_names.as_str()).collect();
+        assert_eq!(vec!["name", "age", "birthdate"], names);
+
+        let types: Vec<TagType> = resolved.definitions.iter().map(|d| d.tag_type).collect();
+        assert_eq!(vec![TagType::Text, TagType::Int, TagType::Date], types);
+    }
+}

--- a/document-server/src/search/search_delegate.rs
+++ b/document-server/src/search/search_delegate.rs
@@ -18,7 +18,7 @@ use doka_cli::request_client::TokenType;
 
 use crate::engine::generator::{
     GenerationError, SearchSqlGenerationMode, TagDefinition, TagDefinitionBuilder, TagDefinitionInterface,
-    compile_search_query, generate_search_sql,
+    generate_search_sql, generate_sql_from_resolved, resolve_filter,
 };
 use crate::filter::analyse_expression;
 use crate::filter::filter_ast::FilterExpressionAST;
@@ -76,7 +76,7 @@ impl SearchDelegate {
 
         let sql_query = try_or_return!(
             generate_search_sql(
-                &filter_expression_ast,
+                *filter_expression_ast,
                 &tag_definition_builder,
                 &select_tags,
                 &order_tags.unwrap_or(vec![]),
@@ -159,10 +159,25 @@ impl SearchDelegate {
         let mut select_tags = build_select_tags(&filter_expression_ast, &order_tags.clone().unwrap_or_default());
         extend_select_tags(&mut select_tags, build_query_request.extra_properties.as_deref().unwrap_or_default());
 
-        let compiled_query = try_or_return!(
-            compile_search_query(
-                &filter_expression_ast,
+        let (resolved_ast, definitions) = try_or_return!(
+            resolve_filter(
+                *filter_expression_ast,
                 &tag_definition_builder,
+                &order_tags.clone().unwrap_or_default(),
+                &entry_session.customer_code,
+            )
+            .await,
+            |e: GenerationError| {
+                log_error!("💣 Fail to resolve filter for build-query, [{:?}], follower=[{}]", e, &self.follower);
+                let msg = SimpleMessage::from(e.to_string());
+                WebType::from_simple(StatusCode::BAD_REQUEST.as_u16(), msg).into_with_context()
+            }
+        );
+
+        let compiled_query = try_or_return!(
+            generate_sql_from_resolved(
+                resolved_ast,
+                definitions,
                 &select_tags,
                 &order_tags.clone().unwrap_or_default(),
                 SearchSqlGenerationMode::Persisted,


### PR DESCRIPTION
Adds Date as a first-class filter type: lexer emits a ValueString, a new filter/type_resolver.rs stage rewrites it to ValueDate(NaiveDate) against the loaded TagDefinitions, and SQL emission renders `tv.value_date <op> DATE 'YYYY-MM-DD'`. LIKE is rejected for Date. 

Refactors compile_search_query into resolve_filter + generate_sql_from_resolved for a single-responsibility pipeline.